### PR TITLE
Not overriding background color for ColoredUi

### DIFF
--- a/ui_colored.go
+++ b/ui_colored.go
@@ -51,5 +51,5 @@ func (u *ColoredUi) colorize(message string, color UiColor) string {
 		attr = 1
 	}
 
-	return fmt.Sprintf("\033[%d;%d;40m%s\033[0m", attr, color.Code, message)
+	return fmt.Sprintf("\033[%d;%dm%s\033[0m", attr, color.Code, message)
 }

--- a/ui_colored_test.go
+++ b/ui_colored_test.go
@@ -16,7 +16,7 @@ func TestColoredUi_Error(t *testing.T) {
 	}
 	ui.Error("foo")
 
-	if mock.ErrorWriter.String() != "\033[0;33;40mfoo\033[0m\n" {
+	if mock.ErrorWriter.String() != "\033[0;33mfoo\033[0m\n" {
 		t.Fatalf("bad: %#v", mock.ErrorWriter.String())
 	}
 }
@@ -29,7 +29,7 @@ func TestColoredUi_Info(t *testing.T) {
 	}
 	ui.Info("foo")
 
-	if mock.OutputWriter.String() != "\033[0;33;40mfoo\033[0m\n" {
+	if mock.OutputWriter.String() != "\033[0;33mfoo\033[0m\n" {
 		t.Fatalf("bad: %#v %#v", mock.OutputWriter.String())
 	}
 }
@@ -42,7 +42,7 @@ func TestColoredUi_Output(t *testing.T) {
 	}
 	ui.Output("foo")
 
-	if mock.OutputWriter.String() != "\033[0;33;40mfoo\033[0m\n" {
+	if mock.OutputWriter.String() != "\033[0;33mfoo\033[0m\n" {
 		t.Fatalf("bad: %#v %#v", mock.OutputWriter.String())
 	}
 }


### PR DESCRIPTION
Not all terminal windows have a black background, so overriding background color makes the colored output look funky.

_Tested on OS X only_
