### PR TITLE
cli: add CLI constructor, support --version, improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go CLI Library
+# Go CLI Library [![GoDoc](https://godoc.org/github.com/mitchellh/cli?status.png)](https://godoc.org/github.com/mitchellh/cli)
 
 cli is a library for implementing powerful command-line interfaces in Go.
 cli is the library that powers the CLI for
@@ -19,3 +19,35 @@ cli is the library that powers the CLI for
 
 * Use of Go interfaces/types makes augmenting various parts of the library a
   piece of cake.
+
+## Example
+
+Below is a simple example of creating and running a CLI
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/mitchellh/cli"
+)
+
+func main() {
+	c := cli.NewCLI("app", "1.0.0")
+	c.Args = os.Args[1:]
+	c.Commands = map[string]cli.CommandFactory{
+		"foo": fooCommandFactory,
+		"bar": barCommandFactory,
+	}
+
+	exitStatus, err := c.Run()
+	if err != nil {
+		log.Println(err)
+	}
+
+	os.Exit(exitStatus)
+}
+```
+

--- a/cli_test.go
+++ b/cli_test.go
@@ -28,6 +28,28 @@ func TestCLIIsHelp(t *testing.T) {
 	}
 }
 
+func TestCLIIsVersion(t *testing.T) {
+	testCases := []struct {
+		args      []string
+		isVersion bool
+	}{
+		{[]string{"foo", "-v"}, true},
+		{[]string{"foo", "--version"}, true},
+		{[]string{"foo", "-v", "bar"}, true},
+		{[]string{"foo", "bar"}, false},
+		{[]string{"-h", "bar"}, false},
+	}
+
+	for _, testCase := range testCases {
+		cli := &CLI{Args: testCase.args}
+		result := cli.IsVersion()
+
+		if result != testCase.isVersion {
+			t.Errorf("Expected '%#v'. Args: %#v", testCase.isVersion, testCase.args)
+		}
+	}
+}
+
 func TestCLIRun(t *testing.T) {
 	command := new(MockCommand)
 	cli := &CLI{


### PR DESCRIPTION
- Add a new CLI constructor for easy building.
- Add `Name` and `Version` fields for a more advanced usage.
- Add support for inbuilt -v/--version just like we have for -h/--help
- Improve README.md. Add an example for the new constructor.
- Add Godoc.org badge for easy access of docs.
- Add tests for -v/-version handling
