### PR TITLE
Ask() should accept spaces

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 )
 
 // Ui is an interface for interacting with the terminal, or "interface"
@@ -53,13 +55,14 @@ func (u *BasicUi) Ask(query string) (string, error) {
 	errCh := make(chan error, 1)
 	lineCh := make(chan string, 1)
 	go func() {
-		var line string
-		if _, err := fmt.Fscanln(u.Reader, &line); err != nil {
+		r := bufio.NewReader(u.Reader)
+		line, err := r.ReadString('\n')
+		if err != nil {
 			errCh <- err
 			return
 		}
 
-		lineCh <- line
+		lineCh <- strings.TrimRight(line, "\r\n")
 	}()
 
 	select {

--- a/ui_test.go
+++ b/ui_test.go
@@ -21,7 +21,7 @@ func TestBasicUi_Ask(t *testing.T) {
 		Writer: writer,
 	}
 
-	go in_w.Write([]byte("foo\nbar\n"))
+	go in_w.Write([]byte("foo bar\nbaz\n"))
 
 	result, err := ui.Ask("Name?")
 	if err != nil {
@@ -32,7 +32,7 @@ func TestBasicUi_Ask(t *testing.T) {
 		t.Fatalf("bad: %#v", writer.String())
 	}
 
-	if result != "foo" {
+	if result != "foo bar" {
 		t.Fatalf("bad: %#v", result)
 	}
 }


### PR DESCRIPTION
`Ask()` currently fails with an unhandled “expected newline” error if the input contains spaces.

This is because [`fmt.Fscanln()`](http://golang.org/pkg/fmt/#Fscanln) stores successive space-separated values into successive arguments but we are only asking for a single (store) argument.
