### PR TITLE
Support subcommands having their own version arguments

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -139,10 +139,12 @@ func (c *CLI) processArgs() {
 			continue
 		}
 
-		// Also lookup for version flag
-		if arg == "-v" || arg == "-version" || arg == "--version" {
-			c.isVersion = true
-			continue
+		// Also lookup for version flag if not in a subcommand
+		if c.subcommand == "" {
+			if arg == "-v" || arg == "-version" || arg == "--version" {
+				c.isVersion = true
+				continue
+			}
 		}
 
 		// If we didn't find a subcommand yet and this is the first non-flag

--- a/cli_test.go
+++ b/cli_test.go
@@ -34,12 +34,15 @@ func TestCLIIsVersion(t *testing.T) {
 		args      []string
 		isVersion bool
 	}{
-		{[]string{"foo", "-v"}, true},
-		{[]string{"foo", "-version"}, true},
-		{[]string{"foo", "--version"}, true},
-		{[]string{"foo", "-v", "bar"}, true},
+		{[]string{"-v"}, true},
+		{[]string{"-version"}, true},
+		{[]string{"--version"}, true},
+		{[]string{"-v", "foo"}, true},
 		{[]string{"foo", "bar"}, false},
 		{[]string{"-h", "bar"}, false},
+		{[]string{"foo", "-v"}, false},
+		{[]string{"foo", "-version"}, false},
+		{[]string{"foo", "--version"}, false},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Currently it is impossible to have an argument called `-version`, `-v`, or `--version` for any subcommands. I have a CLI tool that accepts passing in a version number using the `-version` flag, which worked until 6705537, possibly by mistake.

Basically, the `-v`, `-version`, and `--version` arguments, even if given for a subcommand, trigger the version to be displayed. I would have expected this would be the case only when no subcommand was given like this:

```
# Dumps version
./cli -v
./cli -version
./cli --version

# Lets subcommand handle the flag
./cli sub -v
./cli sub -version
./cli sub --version
```
