### PR TITLE
Added support for setting default commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ func main() {
 		"bar": barCommandFactory,
 	}
 
+    // Optional DefaultCommand that will run if no command in Commands map is found.
+    c.DefaultCommand = defaultCommandFactory
+
 	exitStatus, err := c.Run()
 	if err != nil {
 		log.Println(err)

--- a/cli_test.go
+++ b/cli_test.go
@@ -178,3 +178,38 @@ func TestCLISubcommand(t *testing.T) {
 		}
 	}
 }
+
+func TestCLIDefaultCommand(t *testing.T) {
+	commandFoo := new(MockCommand)
+	commandBar := new(MockCommand)
+	cli := &CLI{
+		Args: []string{"-bar", "-baz"},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return commandFoo, nil
+			},
+		},
+		DefaultCommand: func() (Command, error) {
+			return commandBar, nil
+		},
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != commandBar.RunResult {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if !commandBar.RunCalled {
+		t.Fatalf("run should be called")
+	}
+
+	if !reflect.DeepEqual(commandBar.RunArgs, []string{"-bar", "-baz"}) {
+		t.Fatalf("bad args: %#v", commandBar.RunArgs)
+	}
+
+
+}


### PR DESCRIPTION
I ran into a situation where I needed my program to just launch
something with no subcommand, but also have a set of subcommands to
interact with data and a running daemon. All bases should be covered
here (tests, help text, etc...).