### PR TITLE
Add formatters

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -31,6 +31,26 @@ type Ui interface {
 	Error(string)
 }
 
+// Uif is an interface that expands upon the original Ui interface adding
+// formatter functions.
+type Uif interface {
+	// Uif is an interface that extends the Ui interface, and as such includes
+	// all ui functions.
+	Ui
+
+	// Askf calls Ask after formatting the string.
+	Askf(string, ...interface{}) (string, error)
+
+	// Outputf calls Output after formatting the string.
+	Outputf(string, ...interface{})
+
+	// Infof calls Info after formatting the string.
+	Infof(string, ...interface{})
+
+	// Errorf calls Error after formatting the string.
+	Errorf(string, ...interface{})
+}
+
 // BasicUi is an implementation of Ui that just outputs to the given
 // writer. This UI is not threadsafe by default, but you can wrap it
 // in a ConcurrentUi to make it safe.
@@ -96,6 +116,22 @@ func (u *BasicUi) Info(message string) {
 func (u *BasicUi) Output(message string) {
 	fmt.Fprint(u.Writer, message)
 	fmt.Fprint(u.Writer, "\n")
+}
+
+func (u *BasicUi) Askf(format string, v ...interface{}) (string, error) {
+	return u.Ask(fmt.Sprintf(format, v...))
+}
+
+func (u *BasicUi) Outputf(format string, v ...interface{}) {
+	u.Output(fmt.Sprintf(format, v...))
+}
+
+func (u *BasicUi) Infof(format string, v ...interface{}) {
+	u.Info(fmt.Sprintf(format, v...))
+}
+
+func (u *BasicUi) Errorf(format string, v ...interface{}) {
+	u.Error(fmt.Sprintf(format, v...))
 }
 
 // PrefixedUi is an implementation of Ui that prefixes messages.

--- a/ui_colored.go
+++ b/ui_colored.go
@@ -46,6 +46,22 @@ func (u *ColoredUi) Error(message string) {
 	u.Ui.Error(u.colorize(message, u.ErrorColor))
 }
 
+func (u *ColoredUi) Askf(format string, v ...interface{}) (string, error) {
+	return u.Ask(fmt.Sprintf(format, v...))
+}
+
+func (u *ColoredUi) Outputf(format string, v ...interface{}) {
+	u.Output(fmt.Sprintf(format, v...))
+}
+
+func (u *ColoredUi) Infof(format string, v ...interface{}) {
+	u.Info(fmt.Sprintf(format, v...))
+}
+
+func (u *ColoredUi) Errorf(format string, v ...interface{}) {
+	u.Error(fmt.Sprintf(format, v...))
+}
+
 func (u *ColoredUi) colorize(message string, color UiColor) string {
 	if color.Code == -1 {
 		return message

--- a/ui_colored_test.go
+++ b/ui_colored_test.go
@@ -43,7 +43,7 @@ func TestColoredUi_Info(t *testing.T) {
 	ui.Info("foo")
 
 	if mock.OutputWriter.String() != "\033[0;33mfoo\033[0m\n" {
-		t.Fatalf("bad: %#v %#v", mock.OutputWriter.String())
+		t.Fatalf("bad: %#v", mock.OutputWriter.String())
 	}
 }
 
@@ -56,6 +56,6 @@ func TestColoredUi_Output(t *testing.T) {
 	ui.Output("foo")
 
 	if mock.OutputWriter.String() != "\033[0;33mfoo\033[0m\n" {
-		t.Fatalf("bad: %#v %#v", mock.OutputWriter.String())
+		t.Fatalf("bad: %#v", mock.OutputWriter.String())
 	}
 }

--- a/ui_concurrent.go
+++ b/ui_concurrent.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -37,4 +38,20 @@ func (u *ConcurrentUi) Output(message string) {
 	defer u.l.Unlock()
 
 	u.Ui.Output(message)
+}
+
+func (u *ConcurrentUi) Askf(format string, v ...interface{}) (string, error) {
+	return u.Ask(fmt.Sprintf(format, v...))
+}
+
+func (u *ConcurrentUi) Outputf(format string, v ...interface{}) {
+	u.Output(fmt.Sprintf(format, v...))
+}
+
+func (u *ConcurrentUi) Infof(format string, v ...interface{}) {
+	u.Info(fmt.Sprintf(format, v...))
+}
+
+func (u *ConcurrentUi) Errorf(format string, v ...interface{}) {
+	u.Error(fmt.Sprintf(format, v...))
 }

--- a/ui_mock.go
+++ b/ui_mock.go
@@ -47,6 +47,22 @@ func (u *MockUi) Output(message string) {
 	fmt.Fprint(u.OutputWriter, "\n")
 }
 
+func (u *MockUi) Askf(format string, v ...interface{}) (string, error) {
+	return u.Ask(fmt.Sprintf(format, v...))
+}
+
+func (u *MockUi) Outputf(format string, v ...interface{}) {
+	u.Output(fmt.Sprintf(format, v...))
+}
+
+func (u *MockUi) Infof(format string, v ...interface{}) {
+	u.Info(fmt.Sprintf(format, v...))
+}
+
+func (u *MockUi) Errorf(format string, v ...interface{}) {
+	u.Error(fmt.Sprintf(format, v...))
+}
+
 func (u *MockUi) init() {
 	u.ErrorWriter = new(bytes.Buffer)
 	u.OutputWriter = new(bytes.Buffer)


### PR DESCRIPTION
I'm not really happy with the code duplication.

I thought about instead of making `Uif` an interface making it an wrapper around a `Ui` that exposes the `Ui` interface in addition to the formatter functions.

For example:

```
type Uif struct {
    Ui
}

func (u *Uif) Outputf(format string, v ...interface{}) {
     u.Output(fmt.Sprintf(format, v...))
}
```

Etc.

If that makes sense to you then I'm happy to re-visit the code. If you prefer the interface approach go ahead and merge this as is.

Please let me know if you have any change requests.
