### PR TITLE
Add SubcommandChooser

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,5 +1,7 @@
 package cli
 
+import "io"
+
 // A command is a runnable sub-command of a CLI.
 type Command interface {
 	// Help should return long-form help text that includes the command-line
@@ -21,3 +23,26 @@ type Command interface {
 // We need a factory because we may need to setup some state on the
 // struct that implements the command itself.
 type CommandFactory func() (Command, error)
+
+// OutputTextCommand implemented Command interface and is used to write text to
+// given writer
+type OutputTextCommand struct {
+	writer io.Writer
+	text   string
+}
+
+// Help is part of Command interface
+func (c OutputTextCommand) Help() string {
+	return c.text
+}
+
+// Synopsis is part of Command interface. Return Help()
+func (c OutputTextCommand) Synopsis() string {
+	return c.Help()
+}
+
+// Run is part of Command interface. Args will be ignored.
+func (c OutputTextCommand) Run(_ []string) int {
+	c.writer.Write([]byte(c.Help()))
+	return 1
+}


### PR DESCRIPTION
The SubcommandChooser can be used to customize the behavior when the
default map lookup cannot find the subcommand you want.

Example usage:

busybox-style subcommand invocation

```
// A symbolic link `ls` to binary `busybox` will invoke `busybox ls`
mySubcommandChooser = func(*c cli.CLI) (CommandFactory, error){
    subcommand = os.Args[0]
    if subcommand != c.Name() {
        if subcommandFunc, ok := c.Commands[subcommand]; ok {
            return subcommandFunc, nil
        }
    }
    return cli.DefaultSubcommandChooser(c)
}

c := cli.NewCLI("busybox", "1.0.0")
c.Args = os.Args[1:]
c.Commands = map[string]cli.CommandFactory{
    "ls": lsCommandFactory,
    "cat": catCommandFactory,
}
c.SubcommandChooser = mySubcommandChooser
```

default subcommand

```
// `myapp --help` == `myapp default --help`
mySubcommandChooser = func(*c cli.CLI) (CommandFactory, error) {
    if c.Subcommand() == "" {
        return c.Commands["default"], nil
    }
    return cli.DefaultSubcommandChooser(c)
}
c := cli.NewCLI("myapp", "1.0.0")
c.Args = os.Args[1:]
c.Commands = map[string]cli.CommandFactory{
    "default": defaultCommandFactory,
}
c.SubcommandChooser = mySubcommandChooser
```
