### PR TITLE
Make version number optional and reflect in help

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -23,7 +23,8 @@ type CLI struct {
 	// Name defines the name of the CLI.
 	Name string
 
-	// Version of the CLI.
+	// Version of the CLI. If the version is an empty string, the --version
+	// switch will be omitted from the generated basic help.
 	Version string
 
 	// HelpFunc and HelpWriter are used to output help information, if
@@ -52,7 +53,7 @@ func NewCLI(app, version string) *CLI {
 	return &CLI{
 		Name:     app,
 		Version:  version,
-		HelpFunc: BasicHelpFunc(app),
+		HelpFunc: BasicHelpFunc(app, version != ""),
 	}
 
 }
@@ -129,10 +130,10 @@ func (c *CLI) SubcommandArgs() []string {
 
 func (c *CLI) init() {
 	if c.HelpFunc == nil {
-		c.HelpFunc = BasicHelpFunc("app")
+		c.HelpFunc = BasicHelpFunc("app", c.Version != "")
 
 		if c.Name != "" {
-			c.HelpFunc = BasicHelpFunc(c.Name)
+			c.HelpFunc = BasicHelpFunc(c.Name, c.Version != "")
 		}
 	}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -88,6 +88,34 @@ func TestCLIRun(t *testing.T) {
 	}
 }
 
+func TestCLIWithoutVersion_help(t *testing.T) {
+	command := new(MockCommand)
+	buf := new(bytes.Buffer)
+	cli := &CLI{
+		Version: "",
+		Args:    []string{"", "--version"},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return command, nil
+			},
+		},
+		HelpWriter: buf,
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode == 0 {
+		t.Error("Exit code was 0")
+	}
+
+	if strings.Contains(buf.String(), "--version") {
+		t.Error("Help text contains --version when none was set")
+	}
+}
+
 func TestCLIRun_blank(t *testing.T) {
 	command := new(MockCommand)
 	cli := &CLI{

--- a/help.go
+++ b/help.go
@@ -13,13 +13,20 @@ import (
 type HelpFunc func(map[string]CommandFactory) string
 
 // BasicHelpFunc generates some basic help output that is usually good enough
-// for most CLI applications.
-func BasicHelpFunc(app string) HelpFunc {
+// for most CLI applications. If hasVersion is true, "--version" will be listed
+// as an available option.
+func BasicHelpFunc(app string, hasVersion bool) HelpFunc {
 	return func(commands map[string]CommandFactory) string {
 		var buf bytes.Buffer
-		buf.WriteString(fmt.Sprintf(
-			"usage: %s [--version] [--help] <command> [<args>]\n\n",
-			app))
+		if hasVersion {
+			buf.WriteString(fmt.Sprintf(
+				"usage: %s [--version] [--help] <command> [<args>]\n\n",
+				app))
+		} else {
+			buf.WriteString(fmt.Sprintf(
+				"usage: %s [--help] <command> [<args>]\n\n",
+				app))
+		}
 		buf.WriteString("Available commands are:\n")
 
 		// Get the list of keys so we can sort them, and also get the maximum


### PR DESCRIPTION
This commit modifies the BasicHelpFunc to check whether Version is an empty string, and if it is omits it from the help generated by BasicHelpFunc. It also adds a test of this behaviour.

This is useful in situations where you are using nested CLIs to get aws-cli style user interfaces, and conseuqently only want Version as a top level switch - for example:

```
    aws ec2 --help
```

should not list --version as an option, but

```
    aws --help
```

should list --version as an option.