### PR TITLE
Use cross-platform dependencies in place of golang.org/x/crypto/ssh/terminal

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -9,7 +9,8 @@ import (
 	"os/signal"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/bgentry/speakeasy"
+	"github.com/mattn/go-isatty"
 )
 
 // Ui is an interface for interacting with the terminal, or "interface"
@@ -75,11 +76,8 @@ func (u *BasicUi) ask(query string, secret bool) (string, error) {
 	go func() {
 		var line string
 		var err error
-		stdin := int(os.Stdin.Fd())
-		if secret && terminal.IsTerminal(stdin) {
-			var lineBytes []byte
-			lineBytes, err = terminal.ReadPassword(stdin)
-			line = string(lineBytes)
+		if secret && isatty.IsTerminal(os.Stdin.Fd()) {
+			line, err = speakeasy.Ask("")
 		} else {
 			r := bufio.NewReader(u.Reader)
 			line, err = r.ReadString('\n')


### PR DESCRIPTION
Functions in `golang.org/x/crypto/ssh/terminal` (in particular `terminal.IsTerminal(int)` and `ReadPassword(string)` on the `Terminal` struct which are used in the CLI user interface) are coded directly against system calls, and do not compile on Solaris-derived Unix systems - notably SmartOS.

This commit replaces calls to terminal.IsTerminal with the go-isatty package, which is cross platform, and calls to ReadPassword with the go-speakeasy package in order to be compatible with SmartOS.

This does not affect the public API of the CLI package.