### PR TITLE
Nested subcommands

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -356,25 +356,10 @@ func (c *CLI) processArgs() {
 			if c.commandNested {
 				// Nested CLI, the subcommand is actually the entire
 				// arg list up to a flag that is still a valid subcommand.
-				// TODO: LongestPrefix
-				newI := i
-				for _, arg := range c.Args[i+1:] {
-					if arg == "" || arg[0] == '-' {
-						break
-					}
-
-					subcommand := c.subcommand + " " + arg
-					if _, ok := c.commandTree.Get(subcommand); ok {
-						c.subcommand = subcommand
-					}
-
-					newI++
-				}
-
-				// If we found a subcommand, then move i so that we
-				// get the proper arg list below
-				if strings.ContainsRune(c.subcommand, ' ') {
-					i = newI
+				k, _, ok := c.commandTree.LongestPrefix(strings.Join(c.Args[i:], " "))
+				if ok {
+					c.subcommand = k
+					i += strings.Count(k, " ")
 				}
 			}
 

--- a/cli.go
+++ b/cli.go
@@ -123,13 +123,13 @@ func (c *CLI) Run() (int, error) {
 
 	// Attempt to get the factory function for creating the command
 	// implementation. If the command is invalid or blank, it is an error.
-	commandFunc, ok := c.Commands[c.Subcommand()]
+	raw, ok := c.commandTree.Get(c.Subcommand())
 	if !ok {
 		c.HelpWriter.Write([]byte(c.HelpFunc(c.Commands) + "\n"))
 		return 1, nil
 	}
 
-	command, err := commandFunc()
+	command, err := raw.(CommandFactory)()
 	if err != nil {
 		return 0, err
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -183,6 +183,32 @@ func TestCLIRun_nested(t *testing.T) {
 	}
 }
 
+func TestCLIRun_nestedMissingParent(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cli := &CLI{
+		Args: []string{"foo"},
+		Commands: map[string]CommandFactory{
+			"foo bar": func() (Command, error) {
+				return &MockCommand{SynopsisText: "hi!"}, nil
+			},
+		},
+		HelpWriter: buf,
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != 1 {
+		t.Fatalf("bad exit code: %d", exitCode)
+	}
+
+	if buf.String() != testCommandNestedMissingParent {
+		t.Fatalf("bad: %#v", buf.String())
+	}
+}
+
 func TestCLIRun_printHelp(t *testing.T) {
 	testCases := [][]string{
 		{},
@@ -398,6 +424,14 @@ func TestCLISubcommand_nested(t *testing.T) {
 		}
 	}
 }
+
+const testCommandNestedMissingParent = `This command is accessed by using one of the subcommands below.
+
+Subcommands:
+
+    bar    hi!
+
+`
 
 const testCommandHelpSubcommandsOutput = `donuts
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -262,6 +262,47 @@ func TestCLIRun_printCommandHelp(t *testing.T) {
 	}
 }
 
+func TestCLIRun_printCommandHelpTemplate(t *testing.T) {
+	testCases := [][]string{
+		{"--help", "foo"},
+		{"-h", "foo"},
+	}
+
+	for _, args := range testCases {
+		command := &MockCommandHelpTemplate{
+			MockCommand: MockCommand{
+				HelpText: "donuts",
+			},
+
+			HelpTemplateText: "hello {{.Help}}",
+		}
+
+		buf := new(bytes.Buffer)
+		cli := &CLI{
+			Args: args,
+			Commands: map[string]CommandFactory{
+				"foo": func() (Command, error) {
+					return command, nil
+				},
+			},
+			HelpWriter: buf,
+		}
+
+		exitCode, err := cli.Run()
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if exitCode != 1 {
+			t.Fatalf("bad exit code: %d", exitCode)
+		}
+
+		if buf.String() != "hello "+command.HelpText+"\n" {
+			t.Fatalf("bad: %#v", buf.String())
+		}
+	}
+}
+
 func TestCLISubcommand(t *testing.T) {
 	testCases := []struct {
 		args       []string

--- a/command.go
+++ b/command.go
@@ -1,5 +1,11 @@
 package cli
 
+const (
+	// RunResultHelp is a value that can be returned from Run to signal
+	// to the CLI to render the help output.
+	RunResultHelp = -18511
+)
+
 // A command is a runnable sub-command of a CLI.
 type Command interface {
 	// Help should return long-form help text that includes the command-line
@@ -10,11 +16,29 @@ type Command interface {
 	// Run should run the actual command with the given CLI instance and
 	// command-line arguments. It should return the exit status when it is
 	// finished.
+	//
+	// There are a handful of special exit codes this can return documented
+	// above that change behavior.
 	Run(args []string) int
 
 	// Synopsis should return a one-line, short synopsis of the command.
 	// This should be less than 50 characters ideally.
 	Synopsis() string
+}
+
+// CommandHelpTemplate is an extension of Command that also has a function
+// for returning a template for the help rather than the help itself. In
+// this scenario, both Help and HelpTemplate should be implemented.
+//
+// If CommandHelpTemplate isn't implemented, the Help is output as-is.
+type CommandHelpTemplate interface {
+	// HelpTemplate is the template in text/template format to use for
+	// displaying the Help. The keys available are:
+	//
+	//   * ".Help" - The help text itself
+	//   * ".Subcommands"
+	//
+	HelpTemplate() string
 }
 
 // CommandFactory is a type of function that is a factory for commands.

--- a/command_mock.go
+++ b/command_mock.go
@@ -28,3 +28,15 @@ func (c *MockCommand) Run(args []string) int {
 func (c *MockCommand) Synopsis() string {
 	return c.SynopsisText
 }
+
+// MockCommandHelpTemplate is an implementation of CommandHelpTemplate.
+type MockCommandHelpTemplate struct {
+	MockCommand
+
+	// Settable
+	HelpTemplateText string
+}
+
+func (c *MockCommandHelpTemplate) HelpTemplate() string {
+	return c.HelpTemplateText
+}


### PR DESCRIPTION
This adds support for nested subcommands (`./cli foo bar`) while retaining **complete API backwards compatibility**. This does force compatibility up to Go 1.2, but this is already a 2 year old version.

To specify a subcommand, you just specify the full command string in the commands key. For example, `./cli foo bar` would become the "foo bar" key for your `Commands` configuration. That's it!

When nested subcommands are available, some things change automatically. These are listed below.

**If you're not using nested subcommands,** no behavior should change.

```
   * We use longest prefix matching to find a matching subcommand. This
     means if you register "foo bar" and the user executes "cli foo qux",
     the "foo" commmand will be executed with the arg "qux". It is up to
     you to handle these args. One option is to just return the special
     help return code `RunResultHelp` to display help and exit.

   * The help flag "-h" or "-help" will look at all args to determine
     the help function. For example: "otto apps list -h" will show the
     help for "apps list" but "otto apps -h" will show it for "apps".
     In the normal CLI, only the first subcommand is used.

   * The help flag will list any subcommands that a command takes
     as well as the command's help itself. If there are no subcommands,
     it will note this. If the CLI itself has no subcommands, this entire
     section is omitted.

   * Any parent commands that don't exist are automatically created as
     no-op commands that just show help for other subcommands. For example,
     if you only register "foo bar", then "foo" is automatically created.
```

In addition to nested subcommands, this PR adds (to support this feature):

  * A new optional interface `CommandHelpTemplate` that when implemented can be used to customize the format of the help output with subcommand listings.

  * A new special return code specified by constant `RunResultHelp` that forces the CLI to output help. 
