### PR TITLE
'--help' and '--version' options returns exit status 1.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -119,7 +119,7 @@ func (c *CLI) Run() (int, error) {
 	// Just show the version and exit if instructed.
 	if c.IsVersion() && c.Version != "" {
 		c.HelpWriter.Write([]byte(c.Version + "\n"))
-		return 1, nil
+		return 0, nil
 	}
 
 	// If there is an invalid flag, then error
@@ -147,7 +147,7 @@ func (c *CLI) Run() (int, error) {
 	// If we've been instructed to just print the help, then print it
 	if c.IsHelp() {
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	code := command.Run(c.SubcommandArgs())

--- a/cli.go
+++ b/cli.go
@@ -122,6 +122,12 @@ func (c *CLI) Run() (int, error) {
 		return 0, nil
 	}
 
+	// Just print the help when only '-h' or '--help' is passed.
+	if c.IsHelp() && c.Subcommand() == "" {
+		c.HelpWriter.Write([]byte(c.HelpFunc(c.Commands) + "\n"))
+		return 0, nil
+	}
+
 	// If there is an invalid flag, then error
 	if len(c.topFlags) > 0 {
 		c.HelpWriter.Write([]byte(

--- a/cli.go
+++ b/cli.go
@@ -141,7 +141,7 @@ func (c *CLI) Run() (int, error) {
 
 	command, err := raw.(CommandFactory)()
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 
 	// If we've been instructed to just print the help, then print it

--- a/cli_test.go
+++ b/cli_test.go
@@ -278,7 +278,7 @@ func TestCLIRun_printCommandHelp(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 
@@ -321,7 +321,7 @@ func TestCLIRun_printCommandHelpSubcommands(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 
@@ -362,7 +362,7 @@ func TestCLIRun_printCommandHelpTemplate(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -211,8 +211,47 @@ func TestCLIRun_nestedMissingParent(t *testing.T) {
 
 func TestCLIRun_printHelp(t *testing.T) {
 	testCases := [][]string{
-		{},
 		{"-h"},
+		{"--help"},
+	}
+
+	for _, testCase := range testCases {
+		buf := new(bytes.Buffer)
+		helpText := "foo"
+
+		cli := &CLI{
+			Args: testCase,
+			Commands: map[string]CommandFactory{
+				"foo": func() (Command, error) {
+					return new(MockCommand), nil
+				},
+			},
+			HelpFunc: func(map[string]CommandFactory) string {
+				return helpText
+			},
+			HelpWriter: buf,
+		}
+
+		code, err := cli.Run()
+		if err != nil {
+			t.Errorf("Args: %#v. Error: %s", testCase, err)
+			continue
+		}
+
+		if code != 0 {
+			t.Errorf("Args: %#v. Code: %d", testCase, code)
+			continue
+		}
+
+		if !strings.Contains(buf.String(), helpText) {
+			t.Errorf("Args: %#v. Text: %v", testCase, buf.String())
+		}
+	}
+}
+
+func TestCLIRun_printHelpIllegal(t *testing.T) {
+	testCases := [][]string{
+		{},
 		{"i-dont-exist"},
 		{"-bad-flag", "foo"},
 	}


### PR DESCRIPTION
Now, `{command} --help` and `{command} --version` returns exit status 1. For example, 

```
$ ./bin/packer --help
...
$ echo $?
1
$ ./bin/packer --version
0.8.7
$ echo $?
1
```

These are normal cases, thus exit status 0 is better I think.
This PR changes the behavior as follows.

```
$ ./bin/packer --help
...
$ echo $?
0
$ ./bin/packer --version
0.8.7
$ echo $?
0
```

Could you check it?
