### PR TITLE
Look for help even if a subcommand exists

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -387,14 +387,15 @@ func (c *CLI) helpCommands(prefix string) map[string]CommandFactory {
 
 func (c *CLI) processArgs() {
 	for i, arg := range c.Args {
+		if arg == "-h" || arg == "-help" || arg == "--help" {
+			c.isHelp = true
+			continue
+		}
+
 		if c.subcommand == "" {
 			// Check for version and help flags if not in a subcommand
 			if arg == "-v" || arg == "-version" || arg == "--version" {
 				c.isVersion = true
-				continue
-			}
-			if arg == "-h" || arg == "-help" || arg == "--help" {
-				c.isHelp = true
 				continue
 			}
 

--- a/cli.go
+++ b/cli.go
@@ -81,7 +81,6 @@ type CLI struct {
 	commandTree    *radix.Tree
 	commandNested  bool
 	isHelp         bool
-	isPostDashes   bool
 	subcommand     string
 	subcommandArgs []string
 	topFlags       []string
@@ -389,27 +388,20 @@ func (c *CLI) helpCommands(prefix string) map[string]CommandFactory {
 func (c *CLI) processArgs() {
 	for i, arg := range c.Args {
 		if arg == "--" {
-			c.isPostDashes = true
-			continue
+			break
 		}
 
-		// Check for help flags unless we have previously seen "--", which is an
-		// indication of another command entirely, so we do not want to parse those
-		// flags.
-		if !c.isPostDashes {
-			if arg == "-h" || arg == "-help" || arg == "--help" {
-				c.isHelp = true
-				continue
-			}
+		// Check for help flags.
+		if arg == "-h" || arg == "-help" || arg == "--help" {
+			c.isHelp = true
+			continue
 		}
 
 		if c.subcommand == "" {
 			// Check for version flags if not in a subcommand.
-			if !c.isPostDashes {
-				if arg == "-v" || arg == "-version" || arg == "--version" {
-					c.isVersion = true
-					continue
-				}
+			if arg == "-v" || arg == "-version" || arg == "--version" {
+				c.isVersion = true
+				continue
 			}
 
 			if arg != "" && arg[0] == '-' {

--- a/cli_test.go
+++ b/cli_test.go
@@ -20,9 +20,10 @@ func TestCLIIsHelp(t *testing.T) {
 		{[]string{"-h", "foo"}, true},
 		{[]string{"foo", "bar"}, false},
 		{[]string{"-v", "bar"}, false},
-		{[]string{"foo", "-h"}, false},
-		{[]string{"foo", "-help"}, false},
-		{[]string{"foo", "--help"}, false},
+		{[]string{"foo", "-h"}, true},
+		{[]string{"foo", "-help"}, true},
+		{[]string{"foo", "--help"}, true},
+		{[]string{"foo", "bar", "-h"}, true},
 	}
 
 	for _, testCase := range testCases {

--- a/cli_test.go
+++ b/cli_test.go
@@ -24,6 +24,11 @@ func TestCLIIsHelp(t *testing.T) {
 		{[]string{"foo", "-help"}, true},
 		{[]string{"foo", "--help"}, true},
 		{[]string{"foo", "bar", "-h"}, true},
+		{[]string{"foo", "bar", "-help"}, true},
+		{[]string{"foo", "bar", "--help"}, true},
+		{[]string{"foo", "bar", "--", "zip", "-h"}, false},
+		{[]string{"foo", "bar", "--", "zip", "-help"}, false},
+		{[]string{"foo", "bar", "--", "zip", "--help"}, false},
 	}
 
 	for _, testCase := range testCases {
@@ -41,6 +46,9 @@ func TestCLIIsVersion(t *testing.T) {
 		args      []string
 		isVersion bool
 	}{
+		{[]string{"--", "-v"}, false},
+		{[]string{"--", "-version"}, false},
+		{[]string{"--", "--version"}, false},
 		{[]string{"-v"}, true},
 		{[]string{"-version"}, true},
 		{[]string{"--version"}, true},
@@ -50,6 +58,9 @@ func TestCLIIsVersion(t *testing.T) {
 		{[]string{"foo", "-v"}, false},
 		{[]string{"foo", "-version"}, false},
 		{[]string{"foo", "--version"}, false},
+		{[]string{"foo", "--", "zip", "-v"}, false},
+		{[]string{"foo", "--", "zip", "-version"}, false},
+		{[]string{"foo", "--", "zip", "--version"}, false},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This fixes an issue where multiple subcommands are nested, but the user is requesting help for a deeply nested command.

It's strange that the tests specifically tested the _opposite_ of this behavior, so I'm not sure if this is right @mitchellh 