### PR TITLE
Sort subcommands by name

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -294,7 +294,7 @@ func (c *CLI) commandHelp(command Command) {
 		// Get the matching keys
 		subcommands := c.helpCommands(c.Subcommand())
 		keys := make([]string, 0, len(subcommands))
-		for k, _ := range subcommands {
+		for k := range subcommands {
 			keys = append(keys, k)
 		}
 
@@ -311,8 +311,13 @@ func (c *CLI) commandHelp(command Command) {
 
 		// Go through and create their structures
 		subcommandsTpl = make([]map[string]interface{}, 0, len(subcommands))
-		for k, raw := range subcommands {
+		for _, k := range keys {
 			// Get the command
+			raw, ok := subcommands[k]
+			if !ok {
+				c.HelpWriter.Write([]byte(fmt.Sprintf(
+					"Error getting subcommand %q", k)))
+			}
 			sub, err := raw()
 			if err != nil {
 				c.HelpWriter.Write([]byte(fmt.Sprintf(

--- a/cli_test.go
+++ b/cli_test.go
@@ -409,6 +409,15 @@ func TestCLIRun_printCommandHelpSubcommands(t *testing.T) {
 				"foo bar": func() (Command, error) {
 					return &MockCommand{SynopsisText: "hi!"}, nil
 				},
+				"foo zip": func() (Command, error) {
+					return &MockCommand{SynopsisText: "hi!"}, nil
+				},
+				"foo zap": func() (Command, error) {
+					return &MockCommand{SynopsisText: "hi!"}, nil
+				},
+				"foo banana": func() (Command, error) {
+					return &MockCommand{SynopsisText: "hi!"}, nil
+				},
 				"foo longer": func() (Command, error) {
 					return &MockCommand{SynopsisText: "hi!"}, nil
 				},
@@ -541,7 +550,10 @@ const testCommandHelpSubcommandsOutput = `donuts
 
 Subcommands:
 
+    banana    hi!
     bar       hi!
     longer    hi!
+    zap       hi!
+    zip       hi!
 
 `


### PR DESCRIPTION
The code to sort already existed, but then we never actually printed them in that order.

There was a test for this, but I think the map was too small, so it was mostly always working...

/cc @mitchellh 