### PR TITLE
Add Print to interface

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -33,10 +33,10 @@ type Ui interface {
 	// Ui implementors some flexibility with output formats.
 	Info(string)
 
-	// Print is called when standard output is required to not have a new line
+	// WriteString is called when standard output is required to not have a new line
 	// appended to the message. Useful when stringing together multiple writes
 	// to the same line
-	Print(string)
+	WriteString(string)
 
 	// Error is used for any error messages that might appear on standard
 	// error.
@@ -128,7 +128,7 @@ func (u *BasicUi) Output(message string) {
 	fmt.Fprint(u.Writer, "\n")
 }
 
-func (u *BasicUi) Print(message string) {
+func (u *BasicUi) WriteString(message string) {
 	fmt.Fprint(u.Writer, message)
 }
 
@@ -142,7 +142,7 @@ type PrefixedUi struct {
 	AskSecretPrefix string
 	OutputPrefix    string
 	InfoPrefix      string
-	PrintPrefix     string
+	StringPrefix    string
 	ErrorPrefix     string
 	WarnPrefix      string
 	Ui              Ui
@@ -188,12 +188,12 @@ func (u *PrefixedUi) Output(message string) {
 	u.Ui.Output(message)
 }
 
-func (u *PrefixedUi) Print(message string) {
+func (u *PrefixedUi) WriteString(message string) {
 	if message != "" {
-		message = fmt.Sprintf("%s%s", u.PrintPrefix, message)
+		message = fmt.Sprintf("%s%s", u.StringPrefix, message)
 	}
 
-	u.Ui.Print(message)
+	u.Ui.WriteString(message)
 }
 
 func (u *PrefixedUi) Warn(message string) {

--- a/ui.go
+++ b/ui.go
@@ -212,7 +212,7 @@ type AdvancedPrefixedUi struct {
 }
 
 func (u *AdvancedPrefixedUi) WriteString(message string) {
-	if message != "" {
+	if u.StringPrefix != "" {
 		message = fmt.Sprintf("%s%s", u.StringPrefix, message)
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -33,11 +33,6 @@ type Ui interface {
 	// Ui implementors some flexibility with output formats.
 	Info(string)
 
-	// WriteString is called when standard output is required to not have a new line
-	// appended to the message. Useful when stringing together multiple writes
-	// to the same line
-	WriteString(string)
-
 	// Error is used for any error messages that might appear on standard
 	// error.
 	Error(string)
@@ -45,6 +40,15 @@ type Ui interface {
 	// Warn is used for any warning messages that might appear on standard
 	// error.
 	Warn(string)
+}
+
+type AdvancedUi interface {
+	Ui
+
+	// WriteString is called when standard output is required to not have a new line
+	// appended to the message. Useful when stringing together multiple writes
+	// to the same line
+	WriteString(string)
 }
 
 // BasicUi is an implementation of Ui that just outputs to the given
@@ -142,7 +146,6 @@ type PrefixedUi struct {
 	AskSecretPrefix string
 	OutputPrefix    string
 	InfoPrefix      string
-	StringPrefix    string
 	ErrorPrefix     string
 	WarnPrefix      string
 	Ui              Ui
@@ -188,18 +191,30 @@ func (u *PrefixedUi) Output(message string) {
 	u.Ui.Output(message)
 }
 
-func (u *PrefixedUi) WriteString(message string) {
-	if message != "" {
-		message = fmt.Sprintf("%s%s", u.StringPrefix, message)
-	}
-
-	u.Ui.WriteString(message)
-}
-
 func (u *PrefixedUi) Warn(message string) {
 	if message != "" {
 		message = fmt.Sprintf("%s%s", u.WarnPrefix, message)
 	}
 
 	u.Ui.Warn(message)
+}
+
+// AdvancedPrefixedUi is an implementation of Ui that prefixes messages.
+type AdvancedPrefixedUi struct {
+	AskPrefix       string
+	AskSecretPrefix string
+	OutputPrefix    string
+	StringPrefix    string
+	InfoPrefix      string
+	ErrorPrefix     string
+	WarnPrefix      string
+	Ui              AdvancedUi
+}
+
+func (u *AdvancedPrefixedUi) WriteString(message string) {
+	if message != "" {
+		message = fmt.Sprintf("%s%s", u.StringPrefix, message)
+	}
+
+	u.Ui.WriteString(message)
 }

--- a/ui.go
+++ b/ui.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/bgentry/speakeasy"
-	"github.com/mattn/go-isatty"
+	isatty "github.com/mattn/go-isatty"
 )
 
 // Ui is an interface for interacting with the terminal, or "interface"
@@ -32,6 +32,11 @@ type Ui interface {
 	// In general this may be the exact same as Output, but this gives
 	// Ui implementors some flexibility with output formats.
 	Info(string)
+
+	// Print is called when standard output is required to not have a new line
+	// appended to the message. Useful when stringing together multiple writes
+	// to the same line
+	Print(string)
 
 	// Error is used for any error messages that might appear on standard
 	// error.
@@ -123,6 +128,10 @@ func (u *BasicUi) Output(message string) {
 	fmt.Fprint(u.Writer, "\n")
 }
 
+func (u *BasicUi) Print(message string) {
+	fmt.Fprint(u.Writer, message)
+}
+
 func (u *BasicUi) Warn(message string) {
 	u.Error(message)
 }
@@ -133,6 +142,7 @@ type PrefixedUi struct {
 	AskSecretPrefix string
 	OutputPrefix    string
 	InfoPrefix      string
+	PrintPrefix     string
 	ErrorPrefix     string
 	WarnPrefix      string
 	Ui              Ui
@@ -176,6 +186,14 @@ func (u *PrefixedUi) Output(message string) {
 	}
 
 	u.Ui.Output(message)
+}
+
+func (u *PrefixedUi) Print(message string) {
+	if message != "" {
+		message = fmt.Sprintf("%s%s", u.PrintPrefix, message)
+	}
+
+	u.Ui.Print(message)
 }
 
 func (u *PrefixedUi) Warn(message string) {

--- a/ui_colored.go
+++ b/ui_colored.go
@@ -44,10 +44,6 @@ func (u *ColoredUi) Output(message string) {
 	u.Ui.Output(u.colorize(message, u.OutputColor))
 }
 
-func (u *ColoredUi) WriteString(message string) {
-	u.Ui.WriteString(u.colorize(message, u.StringColor))
-}
-
 func (u *ColoredUi) Info(message string) {
 	u.Ui.Info(u.colorize(message, u.InfoColor))
 }
@@ -58,6 +54,20 @@ func (u *ColoredUi) Error(message string) {
 
 func (u *ColoredUi) Warn(message string) {
 	u.Ui.Warn(u.colorize(message, u.WarnColor))
+}
+
+type AdvancedColoredUi struct {
+	OutputColor UiColor
+	StringColor UiColor
+	InfoColor   UiColor
+	ErrorColor  UiColor
+	WarnColor   UiColor
+	Ui          AdvancedUi
+}
+
+func (u *AdvancedColoredUi) WriteString(message string) {
+	cUi := &ColoredUi{}
+	u.Ui.WriteString(cUi.colorize(message, u.StringColor))
 }
 
 func (u *ColoredUi) colorize(message string, color UiColor) string {

--- a/ui_colored.go
+++ b/ui_colored.go
@@ -25,6 +25,7 @@ var (
 // to the given color schemes for the given type of output.
 type ColoredUi struct {
 	OutputColor UiColor
+	PrintColor  UiColor
 	InfoColor   UiColor
 	ErrorColor  UiColor
 	WarnColor   UiColor
@@ -41,6 +42,10 @@ func (u *ColoredUi) AskSecret(query string) (string, error) {
 
 func (u *ColoredUi) Output(message string) {
 	u.Ui.Output(u.colorize(message, u.OutputColor))
+}
+
+func (u *ColoredUi) Print(message string) {
+	u.Ui.Print(u.colorize(message, u.PrintColor))
 }
 
 func (u *ColoredUi) Info(message string) {

--- a/ui_colored.go
+++ b/ui_colored.go
@@ -25,7 +25,7 @@ var (
 // to the given color schemes for the given type of output.
 type ColoredUi struct {
 	OutputColor UiColor
-	PrintColor  UiColor
+	StringColor UiColor
 	InfoColor   UiColor
 	ErrorColor  UiColor
 	WarnColor   UiColor
@@ -44,8 +44,8 @@ func (u *ColoredUi) Output(message string) {
 	u.Ui.Output(u.colorize(message, u.OutputColor))
 }
 
-func (u *ColoredUi) Print(message string) {
-	u.Ui.Print(u.colorize(message, u.PrintColor))
+func (u *ColoredUi) WriteString(message string) {
+	u.Ui.WriteString(u.colorize(message, u.StringColor))
 }
 
 func (u *ColoredUi) Info(message string) {

--- a/ui_colored_test.go
+++ b/ui_colored_test.go
@@ -60,6 +60,19 @@ func TestColoredUi_Output(t *testing.T) {
 	}
 }
 
+func TestColoredUi_Print(t *testing.T) {
+	mock := new(MockUi)
+	ui := &ColoredUi{
+		PrintColor: UiColor{Code: 33},
+		Ui:         mock,
+	}
+	ui.Print("foo")
+
+	if mock.OutputWriter.String() != "\033[0;33mfoo\033[0m" {
+		t.Fatalf("bad: %#v %#v", mock.OutputWriter.String())
+	}
+}
+
 func TestColoredUi_Warn(t *testing.T) {
 	mock := new(MockUi)
 	ui := &ColoredUi{

--- a/ui_colored_test.go
+++ b/ui_colored_test.go
@@ -63,10 +63,10 @@ func TestColoredUi_Output(t *testing.T) {
 func TestColoredUi_Print(t *testing.T) {
 	mock := new(MockUi)
 	ui := &ColoredUi{
-		PrintColor: UiColor{Code: 33},
-		Ui:         mock,
+		StringColor: UiColor{Code: 33},
+		Ui:          mock,
 	}
-	ui.Print("foo")
+	ui.WriteString("foo")
 
 	if mock.OutputWriter.String() != "\033[0;33mfoo\033[0m" {
 		t.Fatalf("bad: %#v %#v", mock.OutputWriter.String())

--- a/ui_colored_test.go
+++ b/ui_colored_test.go
@@ -62,7 +62,7 @@ func TestColoredUi_Output(t *testing.T) {
 
 func TestColoredUi_Print(t *testing.T) {
 	mock := new(MockUi)
-	ui := &ColoredUi{
+	ui := &AdvancedColoredUi{
 		StringColor: UiColor{Code: 33},
 		Ui:          mock,
 	}

--- a/ui_concurrent.go
+++ b/ui_concurrent.go
@@ -46,6 +46,13 @@ func (u *ConcurrentUi) Output(message string) {
 	u.Ui.Output(message)
 }
 
+func (u *ConcurrentUi) Print(message string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	u.Ui.Print(message)
+}
+
 func (u *ConcurrentUi) Warn(message string) {
 	u.l.Lock()
 	defer u.l.Unlock()

--- a/ui_concurrent.go
+++ b/ui_concurrent.go
@@ -46,16 +46,23 @@ func (u *ConcurrentUi) Output(message string) {
 	u.Ui.Output(message)
 }
 
-func (u *ConcurrentUi) WriteString(message string) {
-	u.l.Lock()
-	defer u.l.Unlock()
-
-	u.Ui.WriteString(message)
-}
-
 func (u *ConcurrentUi) Warn(message string) {
 	u.l.Lock()
 	defer u.l.Unlock()
 
 	u.Ui.Warn(message)
+}
+
+// ConcurrentUi is a wrapper around a Ui interface (and implements that
+// interface) making the underlying Ui concurrency safe.
+type AdvancedConcurrentUi struct {
+	Ui AdvancedUi
+	l  sync.Mutex
+}
+
+func (u *AdvancedConcurrentUi) WriteString(message string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	u.Ui.WriteString(message)
 }

--- a/ui_concurrent.go
+++ b/ui_concurrent.go
@@ -46,11 +46,11 @@ func (u *ConcurrentUi) Output(message string) {
 	u.Ui.Output(message)
 }
 
-func (u *ConcurrentUi) Print(message string) {
+func (u *ConcurrentUi) WriteString(message string) {
 	u.l.Lock()
 	defer u.l.Unlock()
 
-	u.Ui.Print(message)
+	u.Ui.WriteString(message)
 }
 
 func (u *ConcurrentUi) Warn(message string) {

--- a/ui_mock.go
+++ b/ui_mock.go
@@ -51,7 +51,7 @@ func (u *MockUi) Output(message string) {
 	fmt.Fprint(u.OutputWriter, "\n")
 }
 
-func (u *MockUi) Print(message string) {
+func (u *MockUi) WriteString(message string) {
 	u.once.Do(u.init)
 
 	fmt.Fprint(u.OutputWriter, message)

--- a/ui_mock.go
+++ b/ui_mock.go
@@ -51,6 +51,12 @@ func (u *MockUi) Output(message string) {
 	fmt.Fprint(u.OutputWriter, "\n")
 }
 
+func (u *MockUi) Print(message string) {
+	u.once.Do(u.init)
+
+	fmt.Fprint(u.OutputWriter, message)
+}
+
 func (u *MockUi) Warn(message string) {
 	u.once.Do(u.init)
 

--- a/ui_test.go
+++ b/ui_test.go
@@ -171,7 +171,7 @@ func TestAdvancedUi_Print(t *testing.T) {
 	}
 }
 
-func TestPrefixedUiPrint(t *testing.T) {
+func TestAdvancedUi_PrintPrefix(t *testing.T) {
 	ui := new(MockUi)
 	p := &AdvancedPrefixedUi{
 		StringPrefix: "foo",

--- a/ui_test.go
+++ b/ui_test.go
@@ -95,6 +95,16 @@ func TestBasicUi_Output(t *testing.T) {
 	}
 }
 
+func TestBasicUi_Print(t *testing.T) {
+	writer := new(bytes.Buffer)
+	ui := &BasicUi{Writer: writer}
+	ui.Print("HELLO")
+
+	if writer.String() != "HELLO" {
+		t.Fatalf("bad: %s", writer.String())
+	}
+}
+
 func TestBasicUi_Warn(t *testing.T) {
 	writer := new(bytes.Buffer)
 	ui := &BasicUi{Writer: writer}
@@ -144,6 +154,19 @@ func TestPrefixedUiOutput(t *testing.T) {
 
 	p.Output("bar")
 	if ui.OutputWriter.String() != "foobar\n" {
+		t.Fatalf("bad: %s", ui.OutputWriter.String())
+	}
+}
+
+func TestPrefixedUiPrint(t *testing.T) {
+	ui := new(MockUi)
+	p := &PrefixedUi{
+		PrintPrefix: "foo",
+		Ui:          ui,
+	}
+
+	p.Print("bar")
+	if ui.OutputWriter.String() != "foobar" {
 		t.Fatalf("bad: %s", ui.OutputWriter.String())
 	}
 }

--- a/ui_test.go
+++ b/ui_test.go
@@ -95,16 +95,6 @@ func TestBasicUi_Output(t *testing.T) {
 	}
 }
 
-func TestBasicUi_Print(t *testing.T) {
-	writer := new(bytes.Buffer)
-	ui := &BasicUi{Writer: writer}
-	ui.WriteString("HELLO")
-
-	if writer.String() != "HELLO" {
-		t.Fatalf("bad: %s", writer.String())
-	}
-}
-
 func TestBasicUi_Warn(t *testing.T) {
 	writer := new(bytes.Buffer)
 	ui := &BasicUi{Writer: writer}
@@ -168,6 +158,16 @@ func TestPrefixedUiWarn(t *testing.T) {
 	p.Warn("bar")
 	if ui.ErrorWriter.String() != "foobar\n" {
 		t.Fatalf("bad: %s", ui.ErrorWriter.String())
+	}
+}
+
+func TestAdvancedUi_Print(t *testing.T) {
+	writer := new(bytes.Buffer)
+	ui := &BasicUi{Writer: writer}
+	ui.WriteString("HELLO")
+
+	if writer.String() != "HELLO" {
+		t.Fatalf("bad: %s", writer.String())
 	}
 }
 

--- a/ui_test.go
+++ b/ui_test.go
@@ -158,19 +158,6 @@ func TestPrefixedUiOutput(t *testing.T) {
 	}
 }
 
-func TestPrefixedUiPrint(t *testing.T) {
-	ui := new(MockUi)
-	p := &PrefixedUi{
-		StringPrefix: "foo",
-		Ui:           ui,
-	}
-
-	p.WriteString("bar")
-	if ui.OutputWriter.String() != "foobar" {
-		t.Fatalf("bad: %s", ui.OutputWriter.String())
-	}
-}
-
 func TestPrefixedUiWarn(t *testing.T) {
 	ui := new(MockUi)
 	p := &PrefixedUi{
@@ -181,5 +168,18 @@ func TestPrefixedUiWarn(t *testing.T) {
 	p.Warn("bar")
 	if ui.ErrorWriter.String() != "foobar\n" {
 		t.Fatalf("bad: %s", ui.ErrorWriter.String())
+	}
+}
+
+func TestPrefixedUiPrint(t *testing.T) {
+	ui := new(MockUi)
+	p := &AdvancedPrefixedUi{
+		StringPrefix: "foo",
+		Ui:           ui,
+	}
+
+	p.WriteString("bar")
+	if ui.OutputWriter.String() != "foobar" {
+		t.Fatalf("bad: %s", ui.OutputWriter.String())
 	}
 }

--- a/ui_test.go
+++ b/ui_test.go
@@ -98,7 +98,7 @@ func TestBasicUi_Output(t *testing.T) {
 func TestBasicUi_Print(t *testing.T) {
 	writer := new(bytes.Buffer)
 	ui := &BasicUi{Writer: writer}
-	ui.Print("HELLO")
+	ui.WriteString("HELLO")
 
 	if writer.String() != "HELLO" {
 		t.Fatalf("bad: %s", writer.String())
@@ -161,11 +161,11 @@ func TestPrefixedUiOutput(t *testing.T) {
 func TestPrefixedUiPrint(t *testing.T) {
 	ui := new(MockUi)
 	p := &PrefixedUi{
-		PrintPrefix: "foo",
-		Ui:          ui,
+		StringPrefix: "foo",
+		Ui:           ui,
 	}
 
-	p.Print("bar")
+	p.WriteString("bar")
 	if ui.OutputWriter.String() != "foobar" {
 		t.Fatalf("bad: %s", ui.OutputWriter.String())
 	}


### PR DESCRIPTION
Adds the `Print()` function to the Ui Interface. Print takes a message
string, and Prints it to the UI without appending a newline character to
the end of the message.

This allows for multiple calls to `Print()` to write output to the same
line of the writer.
