### PR TITLE
Remove newline at the beginning and end of the subcommand template

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -448,7 +448,7 @@ const defaultHelpTemplate = `
 {{.Help}}{{if gt (len .Subcommands) 0}}
 
 Subcommands:
-{{ range $value := .Subcommands }}
+{{- range $value := .Subcommands }}
     {{ $value.NameAligned }}    {{ $value.Synopsis }}{{ end }}
-{{ end }}
+{{- end }}
 `

--- a/cli_test.go
+++ b/cli_test.go
@@ -572,19 +572,15 @@ func TestCLISubcommand_nested(t *testing.T) {
 const testCommandNestedMissingParent = `This command is accessed by using one of the subcommands below.
 
 Subcommands:
-
     bar    hi!
-
 `
 
 const testCommandHelpSubcommandsOutput = `donuts
 
 Subcommands:
-
     banana    hi!
     bar       hi!
     longer    hi!
     zap       hi!
     zip       hi!
-
 `


### PR DESCRIPTION
This fixes the newline that gets appended within the range in the subcommands template. The reason for this is it makes the CLI UI a little inconsistent with the `Commands:` help text not having a newline at the beginning or at the end of the `All other commands:` piece of the help text in Terraform. It also just looks better, IMHO. :)
