### PR TITLE
0 exit code for normal commands

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -159,7 +159,7 @@ func (c *CLI) Run() (int, error) {
 	if code == RunResultHelp {
 		// Requesting help
 		c.commandHelp(command)
-		return 0, nil
+		return 1, nil
 	}
 
 	return code, nil

--- a/cli.go
+++ b/cli.go
@@ -120,7 +120,7 @@ func (c *CLI) Run() (int, error) {
 	// Just show the version and exit if instructed.
 	if c.IsVersion() && c.Version != "" {
 		c.HelpWriter.Write([]byte(c.Version + "\n"))
-		return 1, nil
+		return 0, nil
 	}
 
 	// Attempt to get the factory function for creating the command
@@ -128,18 +128,22 @@ func (c *CLI) Run() (int, error) {
 	raw, ok := c.commandTree.Get(c.Subcommand())
 	if !ok {
 		c.HelpWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
+		// Show help and exit normally if we don't pass a command and want help.
+		if c.isHelp && c.Subcommand() == "" {
+			return 0, nil
+		}
 		return 1, nil
 	}
 
 	command, err := raw.(CommandFactory)()
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 
 	// If we've been instructed to just print the help, then print it
 	if c.IsHelp() {
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	// If there is an invalid flag, then error
@@ -155,7 +159,7 @@ func (c *CLI) Run() (int, error) {
 	if code == RunResultHelp {
 		// Requesting help
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	return code, nil

--- a/cli_test.go
+++ b/cli_test.go
@@ -288,7 +288,7 @@ func TestCLIRun_nestedMissingParent(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if exitCode != 0 {
+	if exitCode != 1 {
 		t.Fatalf("bad exit code: %d", exitCode)
 	}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -230,7 +230,7 @@ func TestCLIRun_helpNested(t *testing.T) {
 		t.Fatalf("Error: %s", err)
 	}
 
-	if code != 1 {
+	if code != 0 {
 		t.Fatalf("Code: %d", code)
 	}
 
@@ -288,7 +288,7 @@ func TestCLIRun_nestedMissingParent(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if exitCode != 1 {
+	if exitCode != 0 {
 		t.Fatalf("bad exit code: %d", exitCode)
 	}
 
@@ -298,11 +298,15 @@ func TestCLIRun_nestedMissingParent(t *testing.T) {
 }
 
 func TestCLIRun_printHelp(t *testing.T) {
-	testCases := [][]string{
-		{},
-		{"-h"},
-		{"i-dont-exist"},
-		{"-bad-flag", "foo"},
+	testCases := []struct {
+		args     []string
+		exitCode int
+	}{
+		{[]string{}, 1},
+		{[]string{"-h"}, 0},
+		{[]string{"i-dont-exist"}, 1},
+		{[]string{"-h", "i-dont-exist"}, 1},
+		{[]string{"-bad-flag", "foo"}, 1},
 	}
 
 	for _, testCase := range testCases {
@@ -310,7 +314,7 @@ func TestCLIRun_printHelp(t *testing.T) {
 		helpText := "foo"
 
 		cli := &CLI{
-			Args: testCase,
+			Args: testCase.args,
 			Commands: map[string]CommandFactory{
 				"foo": func() (Command, error) {
 					return &MockCommand{HelpText: helpText}, nil
@@ -338,12 +342,12 @@ func TestCLIRun_printHelp(t *testing.T) {
 
 		code, err := cli.Run()
 		if err != nil {
-			t.Errorf("Args: %#v. Error: %s", testCase, err)
+			t.Errorf("Args: %#v. Error: %s", testCase.args, err)
 			continue
 		}
 
-		if code != 1 {
-			t.Errorf("Args: %#v. Code: %d", testCase, code)
+		if code != testCase.exitCode {
+			t.Errorf("Args: %#v. Code: %d", testCase.args, code)
 			continue
 		}
 
@@ -384,7 +388,7 @@ func TestCLIRun_printCommandHelp(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 
@@ -421,7 +425,7 @@ func TestCLIRun_printCommandHelpNested(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 
@@ -476,7 +480,7 @@ func TestCLIRun_printCommandHelpSubcommands(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 
@@ -517,7 +521,7 @@ func TestCLIRun_printCommandHelpTemplate(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if exitCode != 1 {
+		if exitCode != 0 {
 			t.Fatalf("bad exit code: %d", exitCode)
 		}
 


### PR DESCRIPTION
We shouldn't have a non-zero exit code when we're asking for the version or for help.

We should also have a non-zero exit code if we get an error