### PR TITLE
Add Vault to README and remove newline from subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ cli is the library that powers the CLI for
 [Packer](https://github.com/mitchellh/packer),
 [Serf](https://github.com/hashicorp/serf),
 [Consul](https://github.com/hashicorp/consul),
+[Vault](https://github.com/hashicorp/vault),
 [Terraform](https://github.com/hashicorp/terraform), and
 [Nomad](https://github.com/hashicorp/nomad).
 

--- a/cli.go
+++ b/cli.go
@@ -454,7 +454,7 @@ const defaultHelpTemplate = `
 {{.Help}}{{if gt (len .Subcommands) 0}}
 
 Subcommands:
-{{ range $value := .Subcommands }}
+{{- range $value := .Subcommands }}
     {{ $value.NameAligned }}    {{ $value.Synopsis }}{{ end }}
-{{ end }}
+{{- end }}
 `

--- a/cli_test.go
+++ b/cli_test.go
@@ -584,19 +584,15 @@ func TestCLISubcommand_nested(t *testing.T) {
 const testCommandNestedMissingParent = `This command is accessed by using one of the subcommands below.
 
 Subcommands:
-
     bar    hi!
-
 `
 
 const testCommandHelpSubcommandsOutput = `donuts
 
 Subcommands:
-
     banana    hi!
     bar       hi!
     longer    hi!
     zap       hi!
     zip       hi!
-
 `


### PR DESCRIPTION
Removing the newline from subcommands is for consistency reasons.