### PR TITLE
mockui: fix data race and nil panic

### DIFF
--- a/ui_mock.go
+++ b/ui_mock.go
@@ -7,12 +7,25 @@ import (
 	"sync"
 )
 
-// MockUi is a mock UI that is used for tests and is exported publicly for
-// use in external tests if needed as well.
+// NewMockUi returns a fully initialized MockUi instance
+// which is safe for concurrent use.
+func NewMockUi() *MockUi {
+	m := new(MockUi)
+	m.once.Do(m.init)
+	return m
+}
+
+// MockUi is a mock UI that is used for tests and is exported publicly
+// for use in external tests if needed as well. Do not instantite this
+// directly since the buffers will be initialized on the first write. If
+// there is no write then you will get a nil panic. Please use the
+// NewMockUi() constructor function instead. You can fix your code with
+//
+//  sed -i -e 's/new(cli.MockUi)/cli.NewMockUi()/g' *_test.go
 type MockUi struct {
 	InputReader  io.Reader
-	ErrorWriter  *bytes.Buffer
-	OutputWriter *bytes.Buffer
+	ErrorWriter  *syncBuffer
+	OutputWriter *syncBuffer
 
 	once sync.Once
 }
@@ -59,6 +72,36 @@ func (u *MockUi) Warn(message string) {
 }
 
 func (u *MockUi) init() {
-	u.ErrorWriter = new(bytes.Buffer)
-	u.OutputWriter = new(bytes.Buffer)
+	u.ErrorWriter = new(syncBuffer)
+	u.OutputWriter = new(syncBuffer)
+}
+
+type syncBuffer struct {
+	sync.RWMutex
+	b bytes.Buffer
+}
+
+func (b *syncBuffer) Write(data []byte) (int, error) {
+	b.Lock()
+	defer b.Unlock()
+	return b.b.Write(data)
+}
+
+func (b *syncBuffer) Read(data []byte) (int, error) {
+	b.RLock()
+	defer b.RUnlock()
+	return b.b.Read(data)
+}
+
+func (b *syncBuffer) Reset() {
+	b.Lock()
+	b.b.Reset()
+	b.Unlock()
+}
+
+func (b *syncBuffer) String() string {
+	b.RLock()
+	data := b.b.Bytes()
+	b.RUnlock()
+	return string(data)
 }


### PR DESCRIPTION
This patch fixes two issues with MockUi which result either in a nil
panic or a data race. The nil panic happens when the no output was
written before the String() method is called. Since the buffers are
initialized on the first write there is no chance to initialize the
buffers. With the given design there is no way to fix this without
breaking existing code. Users are encouraged to use the NewMockUi method
which returns a fully initialized MockUi instead of just creating the
MockUi instance manually.

Additionally, the output buffers are not synchronized which triggers a
data race between readers and writers of the buffers. The buffers have
been replaced with synchronized buffers to address this problem.