### PR TITLE
Subcommand and flag autocompletion support (bash + zsh)

### DIFF
--- a/autocomplete.go
+++ b/autocomplete.go
@@ -4,7 +4,7 @@ import (
 	"github.com/posener/complete/cmd/install"
 )
 
-// autocompleteInstaller is an interface to be implemented to peform the
+// autocompleteInstaller is an interface to be implemented to perform the
 // autocomplete installation and uninstallation with a CLI.
 //
 // This interface is not exported because it only exists for unit tests

--- a/autocomplete.go
+++ b/autocomplete.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"github.com/posener/complete/cmd/install"
+)
+
+// autocompleteInstaller is an interface to be implemented to peform the
+// autocomplete installation and uninstallation with a CLI.
+//
+// This interface is not exported because it only exists for unit tests
+// to be able to test that the installation is called properly.
+type autocompleteInstaller interface {
+	Install(string) error
+	Uninstall(string) error
+}
+
+// realAutocompleteInstaller uses the real install package to do the
+// install/uninstall.
+type realAutocompleteInstaller struct{}
+
+func (i *realAutocompleteInstaller) Install(cmd string) error {
+	return install.Install(cmd)
+}
+
+func (i *realAutocompleteInstaller) Uninstall(cmd string) error {
+	return install.Uninstall(cmd)
+}
+
+// mockAutocompleteInstaller is used for tests to record the install/uninstall.
+type mockAutocompleteInstaller struct {
+	InstallCalled   bool
+	UninstallCalled bool
+}
+
+func (i *mockAutocompleteInstaller) Install(cmd string) error {
+	i.InstallCalled = true
+	return nil
+}
+
+func (i *mockAutocompleteInstaller) Uninstall(cmd string) error {
+	i.UninstallCalled = true
+	return nil
+}

--- a/cli.go
+++ b/cli.go
@@ -71,6 +71,9 @@ type CLI struct {
 	// This is enabled by default when NewCLI is called. Otherwise, this
 	// must enabled explicitly.
 	//
+	// Autocomplete requires the "Name" option to be set on CLI. This name
+	// should be set exactly to the binary name that is autocompleted.
+	//
 	// Autocompletion is supported via the github.com/posener/complete
 	// library. This library supports both bash and zsh. To add support
 	// for other shells, please see that library.
@@ -164,6 +167,13 @@ func (c *CLI) Run() (int, error) {
 
 	// If we're attempting to install or uninstall autocomplete then handle
 	if c.Autocomplete {
+		// Autocomplete requires the "Name" to be set so that we know what
+		// command to setup the autocomplete on.
+		if c.Name == "" {
+			return 1, fmt.Errorf(
+				"internal error: CLI.Name must be specified for autocomplete to work")
+		}
+
 		// If both install and uninstall flags are specified, then error
 		if c.isAutocompleteInstall && c.isAutocompleteUninstall {
 			// TODO: Write error message

--- a/cli.go
+++ b/cli.go
@@ -85,13 +85,13 @@ type CLI struct {
 	// for the flag name. These default to `autocomplete-install` and
 	// `autocomplete-uninstall` respectively.
 	//
-	// AutocompleteUi is the Ui to use for confirmation to install/uninstall
-	// the autocompletion handler. If this is nil, then no confirmation
-	// will be prompted.
-	Autocomplete          bool
-	AutocompleteInstall   string
-	AutocompleteUninstall string
-	autocompleteInstaller autocompleteInstaller // For tests
+	// AutocompleteGlobalFlags are a mapping of global flags for
+	// autocompletion. The help and version flags are automatically added.
+	Autocomplete            bool
+	AutocompleteInstall     string
+	AutocompleteUninstall   string
+	AutocompleteGlobalFlags complete.Flags
+	autocompleteInstaller   autocompleteInstaller // For tests
 
 	// HelpFunc and HelpWriter are used to output help information, if
 	// requested.
@@ -374,6 +374,9 @@ func (c *CLI) initAutocomplete() {
 		"-" + c.AutocompleteUninstall: complete.PredictNothing,
 		"-help":    complete.PredictNothing,
 		"-version": complete.PredictNothing,
+	}
+	for k, v := range c.AutocompleteGlobalFlags {
+		cmd.GlobalFlags[k] = v
 	}
 
 	c.autocomplete = complete.New(c.Name, cmd)

--- a/cli.go
+++ b/cli.go
@@ -91,7 +91,6 @@ type CLI struct {
 	Autocomplete          bool
 	AutocompleteInstall   string
 	AutocompleteUninstall string
-	AutocompleteUi        Ui
 	autocompleteInstaller autocompleteInstaller // For tests
 
 	// HelpFunc and HelpWriter are used to output help information, if

--- a/cli.go
+++ b/cli.go
@@ -127,9 +127,10 @@ type CLI struct {
 // NewClI returns a new CLI instance with sensible defaults.
 func NewCLI(app, version string) *CLI {
 	return &CLI{
-		Name:     app,
-		Version:  version,
-		HelpFunc: BasicHelpFunc(app),
+		Name:         app,
+		Version:      version,
+		HelpFunc:     BasicHelpFunc(app),
+		Autocomplete: true,
 	}
 
 }

--- a/cli.go
+++ b/cli.go
@@ -176,8 +176,9 @@ func (c *CLI) Run() (int, error) {
 
 		// If both install and uninstall flags are specified, then error
 		if c.isAutocompleteInstall && c.isAutocompleteUninstall {
-			// TODO: Write error message
-			return 1, nil
+			return 1, fmt.Errorf(
+				"Either the autocomplete install or uninstall flag may " +
+					"be specified, but not both.")
 		}
 
 		// If the install flag is specified, perform the install or uninstall
@@ -383,6 +384,9 @@ func (c *CLI) initAutocomplete() {
 	c.autocomplete = complete.New(c.Name, cmd)
 }
 
+// initAutocompleteSub creates the complete.Command for a subcommand with
+// the given prefix. This will continue recursively for all subcommands.
+// The prefix "" (empty string) can be used for the root command.
 func (c *CLI) initAutocompleteSub(prefix string) complete.Command {
 	var cmd complete.Command
 	walkFn := func(k string, raw interface{}) bool {

--- a/cli_test.go
+++ b/cli_test.go
@@ -615,6 +615,107 @@ func TestCLIRun_printCommandHelpTemplate(t *testing.T) {
 	}
 }
 
+func TestCLIRun_autocompleteBoth(t *testing.T) {
+	command := new(MockCommand)
+	cli := &CLI{
+		Args: []string{
+			"-" + defaultAutocompleteInstall,
+			"-" + defaultAutocompleteUninstall,
+		},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return command, nil
+			},
+		},
+
+		Autocomplete:          true,
+		autocompleteInstaller: &mockAutocompleteInstaller{},
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != 1 {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if command.RunCalled {
+		t.Fatalf("run should not be called")
+	}
+}
+
+func TestCLIRun_autocompleteInstall(t *testing.T) {
+	command := new(MockCommand)
+	installer := new(mockAutocompleteInstaller)
+	cli := &CLI{
+		Args: []string{
+			"-" + defaultAutocompleteInstall,
+		},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return command, nil
+			},
+		},
+
+		Autocomplete:          true,
+		autocompleteInstaller: installer,
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != 0 {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if command.RunCalled {
+		t.Fatalf("run should not be called")
+	}
+
+	if !installer.InstallCalled {
+		t.Fatal("should call install")
+	}
+}
+
+func TestCLIRun_autocompleteUninstall(t *testing.T) {
+	command := new(MockCommand)
+	installer := new(mockAutocompleteInstaller)
+	cli := &CLI{
+		Args: []string{
+			"-" + defaultAutocompleteUninstall,
+		},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return command, nil
+			},
+		},
+
+		Autocomplete:          true,
+		autocompleteInstaller: installer,
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != 0 {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if command.RunCalled {
+		t.Fatalf("run should not be called")
+	}
+
+	if !installer.UninstallCalled {
+		t.Fatal("should call uninstall")
+	}
+}
+
 func TestCLISubcommand(t *testing.T) {
 	testCases := []struct {
 		args       []string

--- a/cli_test.go
+++ b/cli_test.go
@@ -630,6 +630,7 @@ func TestCLIRun_autocompleteBoth(t *testing.T) {
 			},
 		},
 
+		Name:                  "foo",
 		Autocomplete:          true,
 		autocompleteInstaller: &mockAutocompleteInstaller{},
 	}
@@ -661,6 +662,7 @@ func TestCLIRun_autocompleteInstall(t *testing.T) {
 			},
 		},
 
+		Name:                  "foo",
 		Autocomplete:          true,
 		autocompleteInstaller: installer,
 	}
@@ -696,6 +698,7 @@ func TestCLIRun_autocompleteUninstall(t *testing.T) {
 			},
 		},
 
+		Name:                  "foo",
 		Autocomplete:          true,
 		autocompleteInstaller: installer,
 	}
@@ -715,6 +718,35 @@ func TestCLIRun_autocompleteUninstall(t *testing.T) {
 
 	if !installer.UninstallCalled {
 		t.Fatal("should call uninstall")
+	}
+}
+
+func TestCLIRun_autocompleteNoName(t *testing.T) {
+	command := new(MockCommand)
+	installer := new(mockAutocompleteInstaller)
+	cli := &CLI{
+		Args: []string{"foo"},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return command, nil
+			},
+		},
+
+		Autocomplete:          true,
+		autocompleteInstaller: installer,
+	}
+
+	exitCode, err := cli.Run()
+	if err == nil {
+		t.Fatal("should error")
+	}
+
+	if exitCode != 1 {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if command.RunCalled {
+		t.Fatalf("run should not be called")
 	}
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -805,6 +805,47 @@ func TestCLIAutocomplete_root(t *testing.T) {
 	}
 }
 
+func TestCLIAutocomplete_rootGlobalFlags(t *testing.T) {
+	cases := []struct {
+		Completed []string
+		Last      string
+		Expected  []string
+	}{
+		{nil, "-v", []string{"-version"}},
+		{nil, "-t", []string{"-tubes"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Last, func(t *testing.T) {
+			command := new(MockCommand)
+			cli := &CLI{
+				Commands: map[string]CommandFactory{
+					"foo": func() (Command, error) { return command, nil },
+				},
+
+				Autocomplete: true,
+				AutocompleteGlobalFlags: map[string]complete.Predictor{
+					"-tubes": complete.PredictNothing,
+				},
+			}
+
+			// Initialize
+			cli.init()
+
+			// Test the autocompleter
+			actual := cli.autocomplete.Command.Predict(complete.Args{
+				Completed: tc.Completed,
+				Last:      tc.Last,
+			})
+			sort.Strings(actual)
+
+			if !reflect.DeepEqual(actual, tc.Expected) {
+				t.Fatalf("bad prediction: %#v", actual)
+			}
+		})
+	}
+}
+
 func TestCLIAutocomplete_subcommandArgs(t *testing.T) {
 	cases := []struct {
 		Completed []string

--- a/cli_test.go
+++ b/cli_test.go
@@ -636,8 +636,8 @@ func TestCLIRun_autocompleteBoth(t *testing.T) {
 	}
 
 	exitCode, err := cli.Run()
-	if err != nil {
-		t.Fatalf("err: %s", err)
+	if err == nil {
+		t.Fatal("should error")
 	}
 
 	if exitCode != 1 {

--- a/command.go
+++ b/command.go
@@ -26,6 +26,12 @@ type Command interface {
 	Synopsis() string
 }
 
+// CommandAutocomplete is an extension of Command that enables fine-grained
+// autocompletion. Subcommand autocompletion will work even if this interface
+// is not implemented. By implementing this interface, more advanced
+// autocompletion is enabled.
+type CommandAutocomplete interface{}
+
 // CommandHelpTemplate is an extension of Command that also has a function
 // for returning a template for the help rather than the help itself. In
 // this scenario, both Help and HelpTemplate should be implemented.

--- a/command.go
+++ b/command.go
@@ -1,5 +1,9 @@
 package cli
 
+import (
+	"github.com/posener/complete"
+)
+
 const (
 	// RunResultHelp is a value that can be returned from Run to signal
 	// to the CLI to render the help output.
@@ -30,7 +34,17 @@ type Command interface {
 // autocompletion. Subcommand autocompletion will work even if this interface
 // is not implemented. By implementing this interface, more advanced
 // autocompletion is enabled.
-type CommandAutocomplete interface{}
+type CommandAutocomplete interface {
+	// AutocompleteArgs returns the argument predictor for this command.
+	// If argument completion is not supported, this should return
+	// complete.PredictNothing.
+	AutocompleteArgs() complete.Predictor
+
+	// AutocompleteFlags returns a mapping of supported flags and autocomplete
+	// options for this command. The map key for the Flags map should be the
+	// complete flag such as "-foo" or "--foo".
+	AutocompleteFlags() complete.Flags
+}
 
 // CommandHelpTemplate is an extension of Command that also has a function
 // for returning a template for the help rather than the help itself. In

--- a/command_mock.go
+++ b/command_mock.go
@@ -1,5 +1,9 @@
 package cli
 
+import (
+	"github.com/posener/complete"
+)
+
 // MockCommand is an implementation of Command that can be used for tests.
 // It is publicly exported from this package in case you want to use it
 // externally.
@@ -27,6 +31,23 @@ func (c *MockCommand) Run(args []string) int {
 
 func (c *MockCommand) Synopsis() string {
 	return c.SynopsisText
+}
+
+// MockCommandAutocomplete is an implementation of CommandAutocomplete.
+type MockCommandAutocomplete struct {
+	MockCommand
+
+	// Settable
+	AutocompleteArgsValue  complete.Predictor
+	AutocompleteFlagsValue complete.Flags
+}
+
+func (c *MockCommandAutocomplete) AutocompleteArgs() complete.Predictor {
+	return c.AutocompleteArgsValue
+}
+
+func (c *MockCommandAutocomplete) AutocompleteFlags() complete.Flags {
+	return c.AutocompleteFlagsValue
 }
 
 // MockCommandHelpTemplate is an implementation of CommandHelpTemplate.


### PR DESCRIPTION
> **This is 100% backwards compatible.** The only BC note would be: any application using `NewCLI` will now get Autocompletion enabled automatically. This should result in no notice-able behavior change other than a couple flags being introduced since autocompletion requires "installation" (see below) before any behavior changes.

This adds support for bash and zsh autocompletion of subcommands, flags, and arguments.

The value of autocompletion can be specified via Go callbacks. No need to write any bash.

Under the covers, this PR uses the fantastic and full-featured [complete](https://github.com/posener/complete) library. However, knowledge of this library is not required to use the cli lib or to get basic subcommand autocompletion. For more complex autocompletion, integration is required but is built right-in to the CLI lib.

## Enabling Autocompletion

Autocompletion is opt-in. Users of the CLI lib only need to set `Autocomplete` to `true`:

```go
runner := &cli.Cli{
  Commands: ...,

  Autocomplete: true,
}
```

🎉  With that, subcommand autocompletion automatically happens.

## Autocompletion Install/Uninstall

After autocompletion is enabled, the global flags `-autocomplete-install` and `-autocomplete-uninstall` are added. When these are present they install or uninstall the autocompletion handler for your shell, respectively. After installation, the shell must be restarted for autocompletion to take effect.

```sh
$ terraform -autocomplete-install
...
```

## Subcommand Autocompletion

Subcommand autocompletion comes _for free_. No additional code required. 

Terraform example, assume a tab is typed at the end of each prompt line:

```sh
$ terraform f
fmt           force-unlock

$ terraform state p
pull  push
```

## Argument and Flag Autocompletion

Commands may implement the optional `CommandAutocomplete` interface. This interface allows a command to return autocompletion code for arguments and flags. This allows complex integrations. For example, Nomad uses UUIDs for referencing almost anything and argument autocompletion would look like the following:

```sh
$ nomad job-status a
a421c15           afc514d
```

Or continuing Terraform examples, imagine the `-target` flag:

```sh
$ terraform apply -target a
aws_resource.foo           aws_resource.bar
```