### PR TITLE
Add Bytes() to MockUi.syncBuffer

### DIFF
--- a/ui_mock.go
+++ b/ui_mock.go
@@ -100,8 +100,12 @@ func (b *syncBuffer) Reset() {
 }
 
 func (b *syncBuffer) String() string {
+	return string(b.Bytes())
+}
+
+func (b *syncBuffer) Bytes() []byte {
 	b.RLock()
 	data := b.b.Bytes()
 	b.RUnlock()
-	return string(data)
+	return data
 }


### PR DESCRIPTION
This is to satisfy https://github.com/hashicorp/terraform/blob/master/command/fmt_test.go#L146 and allow Terraform to upgrade to the latest version of this library.