### PR TITLE
Properly build autocompletion tree for 2+ deep subcommands

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -398,25 +398,20 @@ func (c *CLI) initAutocomplete() {
 func (c *CLI) initAutocompleteSub(prefix string) complete.Command {
 	var cmd complete.Command
 	walkFn := func(k string, raw interface{}) bool {
+		// Keep track of the full key so that we can nest further if necessary
+		fullKey := k
+
 		if len(prefix) > 0 {
 			// If we have a prefix, trim the prefix + 1 (for the space)
 			// Example: turns "sub one" to "one" with prefix "sub"
 			k = k[len(prefix)+1:]
 		}
 
-		// Keep track of the full key so that we can nest further if necessary
-		fullKey := k
-
-		if idx := strings.LastIndex(k, " "); idx >= 0 {
-			// If there is a space, we trim up to the space
+		if idx := strings.Index(k, " "); idx >= 0 {
+			// If there is a space, we trim up to the space. This turns
+			// "sub sub2 sub3" into "sub". The prefix trim above will
+			// trim our current depth properly.
 			k = k[:idx]
-		}
-
-		if idx := strings.LastIndex(k, " "); idx >= 0 {
-			// This catches the scenario just in case where we see "sub one"
-			// before "sub". This will let us properly setup the subcommand
-			// regardless.
-			k = k[idx+1:]
 		}
 
 		if _, ok := cmd.Sub[k]; ok {

--- a/cli_test.go
+++ b/cli_test.go
@@ -857,6 +857,9 @@ func TestCLIAutocomplete_root(t *testing.T) {
 		// Make sure global flags work on subcommands
 		{[]string{"sub"}, "-v", nil},
 		{[]string{"sub"}, "o", []string{"one"}},
+		{[]string{"sub"}, "su", []string{"sub2"}},
+		{[]string{"sub", "sub2"}, "o", []string{"one"}},
+		{[]string{"deep", "deep2"}, "a", []string{"a1"}},
 	}
 
 	for _, tc := range cases {
@@ -864,11 +867,15 @@ func TestCLIAutocomplete_root(t *testing.T) {
 			command := new(MockCommand)
 			cli := &CLI{
 				Commands: map[string]CommandFactory{
-					"foo":     func() (Command, error) { return command, nil },
-					"nodes":   func() (Command, error) { return command, nil },
-					"noodles": func() (Command, error) { return command, nil },
-					"sub one": func() (Command, error) { return command, nil },
-					"sub two": func() (Command, error) { return command, nil },
+					"foo":           func() (Command, error) { return command, nil },
+					"nodes":         func() (Command, error) { return command, nil },
+					"noodles":       func() (Command, error) { return command, nil },
+					"sub one":       func() (Command, error) { return command, nil },
+					"sub two":       func() (Command, error) { return command, nil },
+					"sub sub2 one":  func() (Command, error) { return command, nil },
+					"sub sub2 two":  func() (Command, error) { return command, nil },
+					"deep deep2 a1": func() (Command, error) { return command, nil },
+					"deep deep2 b2": func() (Command, error) { return command, nil },
 				},
 
 				Autocomplete: true,
@@ -877,8 +884,14 @@ func TestCLIAutocomplete_root(t *testing.T) {
 			// Initialize
 			cli.init()
 
+			// Build All value
+			var all []string
+			all = append(all, tc.Completed...)
+			all = append(all, tc.Last)
+
 			// Test the autocompleter
 			actual := cli.autocomplete.Command.Predict(complete.Args{
+				All:       all,
 				Completed: tc.Completed,
 				Last:      tc.Last,
 			})


### PR DESCRIPTION
This fixes broken logic around traversing the radix tree to get
subcommands that are 2+ deep for autocompletion. There were two issues
around this:

  1.) `fullKey` was being calculated _after_ prefix trimming. This meant
      that the prefix was actually just never right. This doesn't show
      up in subcommands at level 1 (1-indexed) because the prefix
      doesn't matter. However, at level 2 and beyond, they were being
      inserted into the wrong level of the autocompletion map.

  2.) Trimming out extra subcommands was using `LastIndex` instead of
      `Index`. This meant that `sub sub2 sub3` would turn into `sub
      sub2` when we wanted `sub`.

Together, this resulted in behavior where if you had sub commands
`sub sub2 sub3` and did `cmd sub sub2 <tab>` you'd actually see `sub2`
and `sub` show up again.