### PR TITLE
Use exit code 127 when a subcommand is not found

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -216,7 +216,7 @@ func (c *CLI) Run() (int, error) {
 	raw, ok := c.commandTree.Get(c.Subcommand())
 	if !ok {
 		c.HelpWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
-		return 1, nil
+		return 127, nil
 	}
 
 	command, err := raw.(CommandFactory)()

--- a/cli_test.go
+++ b/cli_test.go
@@ -161,7 +161,7 @@ func TestCLIRun_prefix(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if exitCode != 1 {
+	if exitCode != 127 {
 		t.Fatalf("bad: %d", exitCode)
 	}
 
@@ -346,10 +346,13 @@ func TestCLIRun_printHelp(t *testing.T) {
 }
 
 func TestCLIRun_printHelpIllegal(t *testing.T) {
-	testCases := [][]string{
-		{},
-		{"i-dont-exist"},
-		{"-bad-flag", "foo"},
+	testCases := []struct {
+		args []string
+		exit int
+	}{
+		{nil, 127},
+		{[]string{"i-dont-exist"}, 127},
+		{[]string{"-bad-flag", "foo"}, 1},
 	}
 
 	for _, testCase := range testCases {
@@ -357,7 +360,7 @@ func TestCLIRun_printHelpIllegal(t *testing.T) {
 		helpText := "foo"
 
 		cli := &CLI{
-			Args: testCase,
+			Args: testCase.args,
 			Commands: map[string]CommandFactory{
 				"foo": func() (Command, error) {
 					return &MockCommand{HelpText: helpText}, nil
@@ -389,7 +392,7 @@ func TestCLIRun_printHelpIllegal(t *testing.T) {
 			continue
 		}
 
-		if code != 1 {
+		if code != testCase.exit {
 			t.Errorf("Args: %#v. Code: %d", testCase, code)
 			continue
 		}


### PR DESCRIPTION
This is canonical as a both a shell exit code as well as how git and other tools behave. There's no easy way to differentiate between a missing subcommand and an actual command error.