### PR TITLE
Fix discrepancy between BasicUi and MockUi

### DIFF
--- a/ui_mock.go
+++ b/ui_mock.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 )
 
@@ -35,9 +37,12 @@ func (u *MockUi) Ask(query string) (string, error) {
 
 	var result string
 	fmt.Fprint(u.OutputWriter, query)
-	if _, err := fmt.Fscanln(u.InputReader, &result); err != nil {
+	r := bufio.NewReader(u.InputReader)
+	line, err := r.ReadString('\n')
+	if err != nil {
 		return "", err
 	}
+	result = strings.TrimRight(line, "\r\n")
 
 	return result, nil
 }

--- a/ui_mock_test.go
+++ b/ui_mock_test.go
@@ -1,9 +1,44 @@
 package cli
 
 import (
+	"io"
 	"testing"
 )
 
 func TestMockUi_implements(t *testing.T) {
 	var _ Ui = new(MockUi)
+}
+
+func TestMockUi_Ask(t *testing.T) {
+	tests := []struct {
+		name           string
+		query, input   string
+		expectedResult string
+	}{
+		{"EmptyString", "Middle Name?", "\n", ""},
+		{"NonEmptyString", "Name?", "foo bar\nbaz\n", "foo bar"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in_r, in_w := io.Pipe()
+			defer in_r.Close()
+			defer in_w.Close()
+
+			ui := &MockUi{
+				InputReader: in_r,
+			}
+
+			go in_w.Write([]byte(tc.input))
+
+			result, err := ui.Ask(tc.query)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			if result != tc.expectedResult {
+				t.Fatalf("bad: %#v", result)
+			}
+		})
+	}
 }


### PR DESCRIPTION
I noticed the `Ask` method on `BasicUi` type uses `bufio.Reader.ReadString()` whereas the `Ask` method on `MockUi` uses `fmt.Fscanln` for reading from `Reader` input. This causes two problems:

When using `BasicUi`, one can enter a string with spaces. However, in tests when using `MockUi`, reading a string with spaces only returns the first word.
When using `BasicUi`, one can press `Enter` key and get a empty string back without any error, while using `MockUi` in tests returns an `unexpected newline` error.

This discrepancy between the actual implementation of `Ask` and the mocked implementation of `Ask` makes testing of the two cases mentioned above very hard.

This PR addresses this issue and make the actual and mocked implementation working the same way.
