### PR TITLE
Now Autocompletion supports Fish.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -87,7 +87,7 @@ type CLI struct {
 	// should be set exactly to the binary name that is autocompleted.
 	//
 	// Autocompletion is supported via the github.com/posener/complete
-	// library. This library supports both bash and zsh. To add support
+	// library. This library supports bash, zsh and fish. To add support
 	// for other shells, please see that library.
 	//
 	// AutocompleteInstall and AutocompleteUninstall are the global flag


### PR DESCRIPTION
Now [posener/complete](https://github.com/posener/complete) supports Fish shell so we can add it to comment.