### PR TITLE
Ignore default command for autocomplete init

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -419,6 +419,11 @@ func (c *CLI) initAutocomplete() {
 func (c *CLI) initAutocompleteSub(prefix string) complete.Command {
 	var cmd complete.Command
 	walkFn := func(k string, raw interface{}) bool {
+		// Ignore the empty key which can be present for default commands.
+		if k == "" {
+			return false
+		}
+
 		// Keep track of the full key so that we can nest further if necessary
 		fullKey := k
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -205,6 +205,32 @@ func TestCLIRun_default(t *testing.T) {
 	}
 }
 
+// GH-74: When using NewCLI with a default command only, Run would
+// stack overflow and crash.
+func TestCLIRun_defaultFromNew(t *testing.T) {
+	commandBar := new(MockCommand)
+
+	cli := NewCLI("test", "0.1.0")
+	cli.Commands = map[string]CommandFactory{
+		"": func() (Command, error) {
+			return commandBar, nil
+		},
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != commandBar.RunResult {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if !commandBar.RunCalled {
+		t.Fatalf("run should be called")
+	}
+}
+
 func TestCLIRun_helpNested(t *testing.T) {
 	helpCalled := false
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Fixes #74 

The empty key results in infinite recursion by looking for subcommands of "". This isn't necessary since first-level commands are always traversed as part of the radix tree. Therefore, we can just ignore "". 