### PR TITLE
Add additional help flag recognition

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -615,7 +615,7 @@ func (c *CLI) processArgs() {
 		}
 
 		// Check for help flags.
-		if arg == "-h" || arg == "-help" || arg == "--help" {
+		if arg == "-?" || arg == "-h" || arg == "-help" || arg == "--help" {
 			c.isHelp = true
 			continue
 		}


### PR DESCRIPTION
I was trying to wire this in to `cli` myself from the outside but I don't know if its possible. This may be due to many years in programming in Windows, but I frequently use `-?` (or previously `/?` although I think that is less used these days) when just on muscle memory to invoke help for a command line tool. Many Linux tools already support it (ie. `git`) so seems like its kind of a convention that `cli` should also recognize.