### PR TITLE
Add support for sending expected output to stdout, and errors to stderr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,14 @@ sudo: false
 
 language: go
 
+env:
+  - GO111MODULE=on
+
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
+  - "1.11"
+  - "1.12"
+  - "1.13"
+  - "1.14"
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ testrace:
 
 # updatedeps installs all the dependencies to run and build
 updatedeps:
-	go list ./... \
-		| xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
-		| grep -v github.com/mitchellh/cli \
-		| xargs go get -f -u -v
+	go mod download
 
 .PHONY: test testrace updatedeps

--- a/cli.go
+++ b/cli.go
@@ -109,17 +109,22 @@ type CLI struct {
 	AutocompleteGlobalFlags    complete.Flags
 	autocompleteInstaller      autocompleteInstaller // For tests
 
-	// HelpFunc and HelpWriter are used to output help information, if
-	// requested.
-	//
 	// HelpFunc is the function called to generate the generic help
 	// text that is shown if help must be shown for the CLI that doesn't
 	// pertain to a specific command.
-	//
-	// HelpWriter is the Writer where the help text is outputted to. If
-	// not specified, it will default to Stderr.
-	HelpFunc   HelpFunc
+	HelpFunc HelpFunc
+
+	// HelpWriter is used to print help text and version when requested.
+	// Defaults to os.Stderr for backwards compatibility.
+	// It is recommended that you set HelpWriter to os.Stdout, and
+	// ErrorWriter to os.Stderr.
 	HelpWriter io.Writer
+
+	// ErrorWriter used to output errors when a command can not be run.
+	// Defaults to the value of HelpWriter for backwards compatibility.
+	// It is recommended that you set HelpWriter to os.Stdout, and
+	// ErrorWriter to os.Stderr.
+	ErrorWriter io.Writer
 
 	//---------------------------------------------------------------
 	// Internal fields set automatically
@@ -228,7 +233,7 @@ func (c *CLI) Run() (int, error) {
 	// implementation. If the command is invalid or blank, it is an error.
 	raw, ok := c.commandTree.Get(c.Subcommand())
 	if !ok {
-		c.HelpWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
+		c.ErrorWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
 		return 127, nil
 	}
 
@@ -239,23 +244,23 @@ func (c *CLI) Run() (int, error) {
 
 	// If we've been instructed to just print the help, then print it
 	if c.IsHelp() {
-		c.commandHelp(command)
+		c.commandHelp(c.HelpWriter, command)
 		return 0, nil
 	}
 
 	// If there is an invalid flag, then error
 	if len(c.topFlags) > 0 {
-		c.HelpWriter.Write([]byte(
+		c.ErrorWriter.Write([]byte(
 			"Invalid flags before the subcommand. If these flags are for\n" +
 				"the subcommand, please put them after the subcommand.\n\n"))
-		c.commandHelp(command)
+		c.commandHelp(c.ErrorWriter, command)
 		return 1, nil
 	}
 
 	code := command.Run(c.SubcommandArgs())
 	if code == RunResultHelp {
 		// Requesting help
-		c.commandHelp(command)
+		c.commandHelp(c.ErrorWriter, command)
 		return 1, nil
 	}
 
@@ -309,6 +314,9 @@ func (c *CLI) init() {
 
 	if c.HelpWriter == nil {
 		c.HelpWriter = os.Stderr
+	}
+	if c.ErrorWriter == nil {
+		c.ErrorWriter = c.HelpWriter
 	}
 
 	// Build our hidden commands
@@ -404,8 +412,8 @@ func (c *CLI) initAutocomplete() {
 		cmd.Flags = map[string]complete.Predictor{
 			"-" + c.AutocompleteInstall:   complete.PredictNothing,
 			"-" + c.AutocompleteUninstall: complete.PredictNothing,
-			"-help":    complete.PredictNothing,
-			"-version": complete.PredictNothing,
+			"-help":                       complete.PredictNothing,
+			"-version":                    complete.PredictNothing,
 		}
 	}
 	cmd.GlobalFlags = c.AutocompleteGlobalFlags
@@ -483,7 +491,7 @@ func (c *CLI) initAutocompleteSub(prefix string) complete.Command {
 	return cmd
 }
 
-func (c *CLI) commandHelp(command Command) {
+func (c *CLI) commandHelp(out io.Writer, command Command) {
 	// Get the template to use
 	tpl := strings.TrimSpace(defaultHelpTemplate)
 	if t, ok := command.(CommandHelpTemplate); ok {
@@ -533,12 +541,12 @@ func (c *CLI) commandHelp(command Command) {
 			// Get the command
 			raw, ok := subcommands[k]
 			if !ok {
-				c.HelpWriter.Write([]byte(fmt.Sprintf(
+				c.ErrorWriter.Write([]byte(fmt.Sprintf(
 					"Error getting subcommand %q", k)))
 			}
 			sub, err := raw()
 			if err != nil {
-				c.HelpWriter.Write([]byte(fmt.Sprintf(
+				c.ErrorWriter.Write([]byte(fmt.Sprintf(
 					"Error instantiating %q: %s", k, err)))
 			}
 
@@ -559,13 +567,13 @@ func (c *CLI) commandHelp(command Command) {
 	data["Subcommands"] = subcommandsTpl
 
 	// Write
-	err = t.Execute(c.HelpWriter, data)
+	err = t.Execute(out, data)
 	if err == nil {
 		return
 	}
 
 	// An error, just output...
-	c.HelpWriter.Write([]byte(fmt.Sprintf(
+	c.ErrorWriter.Write([]byte(fmt.Sprintf(
 		"Internal error rendering help: %s", err)))
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -154,7 +154,7 @@ func TestCLIRun_prefix(t *testing.T) {
 				return command, nil
 			},
 		},
-		HelpWriter: buf,
+		ErrorWriter: buf,
 	}
 
 	exitCode, err := cli.Run()
@@ -257,7 +257,7 @@ func TestCLIRun_helpNested(t *testing.T) {
 
 			return ""
 		},
-		HelpWriter: buf,
+		ErrorWriter: buf,
 	}
 
 	code, err := cli.Run()
@@ -347,7 +347,7 @@ func TestCLIRun_nestedMissingParent(t *testing.T) {
 				return &MockCommand{SynopsisText: "hi!"}, nil
 			},
 		},
-		HelpWriter: buf,
+		ErrorWriter: buf,
 	}
 
 	exitCode, err := cli.Run()
@@ -530,7 +530,7 @@ func TestCLIRun_printHelpIllegal(t *testing.T) {
 
 				return helpText
 			},
-			HelpWriter: buf,
+			ErrorWriter: buf,
 		}
 
 		code, err := cli.Run()
@@ -849,7 +849,7 @@ func TestCLIRun_helpHiddenRoot(t *testing.T) {
 
 			return ""
 		},
-		HelpWriter: buf,
+		ErrorWriter: buf,
 	}
 
 	code, err := cli.Run()
@@ -1097,7 +1097,7 @@ func TestCLIRun_autocompleteHelpTab(t *testing.T) {
 		},
 
 		Name:                  "foo",
-		HelpWriter:            buf,
+		ErrorWriter:           buf,
 		Autocomplete:          true,
 		autocompleteInstaller: installer,
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/mitchellh/cli
 
+go 1.11
+
 require (
 	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310
 	github.com/bgentry/speakeasy v0.1.0


### PR DESCRIPTION
# Problem

I encountered this problem when trying to view the Consul help with `consul agent --help`. Any time a command has a lot of help text I send it to a pager (ex: `consul agent --help | less`). I will also quite frequently pipe the help output to grep to quickly find the help text for a flag that I know exists, but I may not remember exactly what it expects as a value.

To my surprise, this did not work! I did some digging and found that all help text (and --version output), even when requested by the user, is always sent to `stderr`. 

I looked to see how other users of this library have handled the problem and I found that `nomad` sets `HelpWriter` to `os.Stdout`. This fixes the problem, but introduces a new problem. If a user runs a command with an invalid flag the error message ends up on `stdout` instead of `stderr`. This can be very confusing to users  when they are trying to run a command with output piped somewhere else, because the error will be hidden.

I believe it is best practice for a CLI to write requested help and version output to stdout, but to send that same output to stderr when it is being printed as a result of an invalid flag or subcommand.

```
$ git --help | wc -l
45
$ cat --help | wc -l
25
$ git bogus 2> /dev/null
$ git branch --bogus 2> /dev/null
$ cat --bogus 2> /dev/null
```

# Solution

This PR addresses the problem by introducing a second `Writer`. I believe it is backwards compatible as the new writer is initialized to the value of the existing `Writer`.

I've seen this problem solved this way in [another cli library](https://github.com/spf13/cobra/blob/95f2f73/command.go#L206-L209) so I thought it may be applicable here as well.