### PR TITLE
Noop autocomplete setup if we're not autocompleting

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -401,6 +402,16 @@ func (c *CLI) initAutocomplete() {
 
 	if c.autocompleteInstaller == nil {
 		c.autocompleteInstaller = &realAutocompleteInstaller{}
+	}
+
+	// We first set c.autocomplete to a noop autocompleter that outputs
+	// to nul so that we can detect if we're autocompleting or not. If we're
+	// not, then we do nothing. This saves a LOT of compute cycles since
+	// initAutoCompleteSub has to walk every command.
+	c.autocomplete = complete.New(c.Name, complete.Command{})
+	c.autocomplete.Out = ioutil.Discard
+	if !c.autocomplete.Complete() {
+		return
 	}
 
 	// Build the root command

--- a/cli_test.go
+++ b/cli_test.go
@@ -1412,6 +1412,10 @@ func TestCLIAutocomplete_subcommandArgs(t *testing.T) {
 				Autocomplete: true,
 			}
 
+			// We need to initialize the autocomplete environment so that
+			// the cli doesn't no-op the autocomplete init
+			defer testAutocomplete(t, "must be non-empty")()
+
 			// Initialize
 			cli.init()
 


### PR DESCRIPTION
Setting up the autocomplete command requires initializing and walking
through every subcommand in order to get their completion
implementations. This means that if `Autocomplete: true` is on the CLI,
every command is initialized on every single invocation.

This PR changes it so that we only initialize the autocompletion command
if we detect that we're actually being invoked for autocompletion.

The practical impact is that if `Autocomplete: true` now and you're NOT
actively autocompleting then we will only init and run the command that
is requested. This is identical behavior to `Autocomplete: false`.

Luckily our tests already "black-box" (mostly) tested autocompletion so
this change can verify that autocompletion still works.