### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Go CLI Library [![GoDoc](https://godoc.org/github.com/mitchellh/cli?status.png)](https://godoc.org/github.com/mitchellh/cli)
+# Go CLI Library
 > A Go library for implementing powerful command-line interfaces
 
+[![GoDoc](https://godoc.org/github.com/mitchellh/cli?status.png)](https://pkg.go.dev/github.com/mitchellh/cli)
 [![GitHub tag](https://img.shields.io/github/tag/mitchellh/cli?include_prereleases=&sort=semver)](https://github.com/mitchellh/cli/releases/)
 [![License](https://img.shields.io/badge/License-Mozilla_Public_License_2.0-blue)](#license)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Go CLI Library [![GoDoc](https://godoc.org/github.com/mitchellh/cli?status.png)](https://godoc.org/github.com/mitchellh/cli)
+> A Go library for implementing powerful command-line interfaces
 
-cli is a library for implementing powerful command-line interfaces in Go.
-cli is the library that powers the CLI for
+[![GitHub tag](https://img.shields.io/github/tag/mitchellh/cli?include_prereleases=&sort=semver)](https://github.com/mitchellh/cli/releases/)
+[![License](https://img.shields.io/badge/License-Mozilla_Public_License_2.0-blue)](#license)
+
+_cli_ is the library that powers the CLI for:
 [Packer](https://github.com/mitchellh/packer),
 [Serf](https://github.com/hashicorp/serf),
 [Consul](https://github.com/hashicorp/consul),
@@ -12,31 +15,23 @@ cli is the library that powers the CLI for
 ## Features
 
 * Easy sub-command based CLIs: `cli foo`, `cli bar`, etc.
-
 * Support for nested subcommands such as `cli foo bar`.
-
 * Optional support for default subcommands so `cli` does something
   other than error.
-
 * Support for shell autocompletion of subcommands, flags, and arguments
   with callbacks in Go. You don't need to write any shell code.
-
-* Automatic help generation for listing subcommands
-
+* Automatic help generation for listing subcommands.
 * Automatic help flag recognition of `-h`, `--help`, etc.
-
 * Automatic version flag recognition of `-v`, `--version`.
-
 * Helpers for interacting with the terminal, such as outputting information,
   asking for input, etc. These are optional, you can always interact with the
   terminal however you choose.
-
 * Use of Go interfaces/types makes augmenting various parts of the library a
   piece of cake.
 
 ## Example
 
-Below is a simple example of creating and running a CLI
+A simple example of creating and running a CLI app:
 
 ```go
 package main
@@ -65,3 +60,6 @@ func main() {
 }
 ```
 
+## License
+
+Released under [Mozilla Public License 2.0](/LICENSE) by [@mitchellh](https://github.com/mitchellh).


### PR DESCRIPTION
- Standardize badges. The godoc link redirects to `https://pkg.go.dev/github.com/mitchellh/cli?utm_source=godoc` so I just used the new address.
- Remove unnecessary spaces in bullets
- Add license section.
