### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST?=./...
+TEST? = ./...
 
 default: test
 
@@ -13,5 +13,3 @@ testrace:
 # updatedeps installs all the dependencies to run and build
 updatedeps:
 	go mod download
-
-.PHONY: test testrace updatedeps


### PR DESCRIPTION
Maybe you use `.PHONY` out of habit but it serves no purpose here. You do not have a file or directory named `test` or `testrace` or `updatedeps` so using phony here does nothing.

Also note that unlike Bash, Make variables can and usually do have spaces around the `=` sign.

See my project here

https://github.com/MichaelCurrin/go-project-template/blob/main/Makefile

Note I only use `.PHONY` against `build` because otherwise `make build` tells me the path exists (`build/` as a directory) so would stop me from running the build command.
