### PR TITLE
Fix bug in which "fooasdf -o=foo" is incorrectly identified as the subcommand "foo"

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -680,12 +680,12 @@ func (c *CLI) processArgs() {
 				}
 
 				// Determine the argument we look to to end subcommands.
-				// We look at all arguments until one has a space. This
-				// disallows commands like: ./cli foo "bar baz". An argument
-				// with a space is always an argument.
+				// We look at all arguments until one is a flag or has a space.
+				// This disallows commands like: ./cli foo "bar baz". An
+				// argument with a space is always an argument.
 				j := 0
 				for k, v := range c.Args[i:] {
-					if strings.ContainsRune(v, ' ') {
+					if strings.ContainsRune(v, ' ') || v[0] == '-' {
 						break
 					}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -171,9 +171,6 @@ func TestCLIRun_prefix(t *testing.T) {
 	}
 }
 
-// NOTE: This failing test is intended to demonstrate incorrect behaviour
-// in which a subcommand with an arbitrary suffix is still parsed as that
-// subcommand, if a supplied argument is also suffixed by that subcommand.
 func TestCLIRun_subcommandSuffix(t *testing.T) {
 	buf := new(bytes.Buffer)
 	command := new(MockCommand)


### PR DESCRIPTION
Fixes #92 

There are a number of ways to fix this. Another approach would be to modify the regex used on line 704 to explicitly exclude cases in which the string ending in the subcommand is itself a flag.