### PR TITLE
Exclude blank args from subcommand parsing

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -682,10 +682,11 @@ func (c *CLI) processArgs() {
 				// Determine the argument we look to to end subcommands.
 				// We look at all arguments until one is a flag or has a space.
 				// This disallows commands like: ./cli foo "bar baz". An
-				// argument with a space is always an argument.
+				// argument with a space is always an argument. A blank
+				// argument is always an argument.
 				j := 0
 				for k, v := range c.Args[i:] {
-					if strings.ContainsRune(v, ' ') || v[0] == '-' {
+					if strings.ContainsRune(v, ' ') || v == "" || v[0] == '-' {
 						break
 					}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -427,6 +427,38 @@ func TestCLIRun_nestedNoArgs(t *testing.T) {
 	}
 }
 
+func TestCLIRun_nestedBlankArg(t *testing.T) {
+	command := new(MockCommand)
+	cli := &CLI{
+		Args: []string{"foo", "", "bar", "-baz"},
+		Commands: map[string]CommandFactory{
+			"foo": func() (Command, error) {
+				return command, nil
+			},
+			"foo bar": func() (Command, error) {
+				return new(MockCommand), nil
+			},
+		},
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if exitCode != command.RunResult {
+		t.Fatalf("bad: %d", exitCode)
+	}
+
+	if !command.RunCalled {
+		t.Fatalf("run should be called")
+	}
+
+	if !reflect.DeepEqual(command.RunArgs, []string{"", "bar", "-baz"}) {
+		t.Fatalf("bad args: %#v", command.RunArgs)
+	}
+}
+
 func TestCLIRun_nestedQuotedCommand(t *testing.T) {
 	command := new(MockCommand)
 	cli := &CLI{


### PR DESCRIPTION
Fixes "index out of range" panic which is caused by checking the first character in blank argument.
```
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0
```